### PR TITLE
Bump node-sdk to 0.0.1-alpha.48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@openfeature/nodejs-sdk": "0.0.1-alpha.10",
+        "@openfeature/nodejs-sdk": "0.0.1-alpha.48",
         "@opentelemetry/api": "^1.1.0",
         "tslib": "^2.3.0"
       },
@@ -3167,9 +3167,9 @@
       }
     },
     "node_modules/@openfeature/nodejs-sdk": {
-      "version": "0.0.1-alpha.10",
-      "resolved": "https://registry.npmjs.org/@openfeature/nodejs-sdk/-/nodejs-sdk-0.0.1-alpha.10.tgz",
-      "integrity": "sha512-d+OU+CF65tsZqUW1HWrT0FF2Z7ty6vJeFSR5E0x2l1uF0u3l7F4LJcHRqwDb3dR65+9TtcmpFdJ2GkPjrBmenw==",
+      "version": "0.0.1-alpha.48",
+      "resolved": "https://registry.npmjs.org/@openfeature/nodejs-sdk/-/nodejs-sdk-0.0.1-alpha.48.tgz",
+      "integrity": "sha512-VA6OSc9l+3TVhAFUmdD8cLUXDi6uCRwHGN+YMsaDpHll1Ag0Zo7UfQvSQiY9w3uCZ8h56Tmt9fDJ0CxJc7puEw==",
       "engines": {
         "node": ">=14"
       }
@@ -16545,9 +16545,9 @@
       }
     },
     "@openfeature/nodejs-sdk": {
-      "version": "0.0.1-alpha.10",
-      "resolved": "https://registry.npmjs.org/@openfeature/nodejs-sdk/-/nodejs-sdk-0.0.1-alpha.10.tgz",
-      "integrity": "sha512-d+OU+CF65tsZqUW1HWrT0FF2Z7ty6vJeFSR5E0x2l1uF0u3l7F4LJcHRqwDb3dR65+9TtcmpFdJ2GkPjrBmenw=="
+      "version": "0.0.1-alpha.48",
+      "resolved": "https://registry.npmjs.org/@openfeature/nodejs-sdk/-/nodejs-sdk-0.0.1-alpha.48.tgz",
+      "integrity": "sha512-VA6OSc9l+3TVhAFUmdD8cLUXDi6uCRwHGN+YMsaDpHll1Ag0Zo7UfQvSQiY9w3uCZ8h56Tmt9fDJ0CxJc7puEw=="
     },
     "@opentelemetry/api": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "private": true,
   "dependencies": {
-    "@openfeature/nodejs-sdk": "0.0.1-alpha.10",
+    "@openfeature/nodejs-sdk": "0.0.1-alpha.48",
     "@opentelemetry/api": "^1.1.0",
     "tslib": "^2.3.0"
   },


### PR DESCRIPTION
We are using an old version of the `node-sdk`, I needed the error but they were not available.