### PR TITLE
fix: Peer dependencies error

### DIFF
--- a/libs/providers/go-feature-flag/package.json
+++ b/libs/providers/go-feature-flag/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "type": "commonjs",
   "peerDependencies": {
-    "@openfeature/nodejs-sdk": "^0.0.1"
+    "@openfeature/nodejs-sdk": "^0.0.1-alpha.53"
   },
   "scripts": {
     "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",

--- a/libs/providers/go-feature-flag/package.json
+++ b/libs/providers/go-feature-flag/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "type": "commonjs",
   "peerDependencies": {
-    "@openfeature/nodejs-sdk": "^0.0.1-alpha.53"
+    "@openfeature/nodejs-sdk": "^0.1.9"
   },
   "scripts": {
     "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",


### PR DESCRIPTION
Since version `0.0.1` is not released yet I had some errors when trying to build a new project using the provider.

```shell
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: test-nodesdk@1.0.0
npm ERR! Found: @openfeature/nodejs-sdk@undefined
npm ERR! node_modules/@openfeature/nodejs-sdk
npm ERR!   @openfeature/nodejs-sdk@"^0.0.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @openfeature/nodejs-sdk@"^0.0.1" from @openfeature/go-feature-flag-provider@0.1.2
npm ERR! node_modules/@openfeature/go-feature-flag-provider
npm ERR!   @openfeature/go-feature-flag-provider@"^0.1.2" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/thomas.poignant/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/thomas.poignant/.npm/_logs/2022-07-22T07_18_14_889Z-debug.log
```

Using the beta version should resolve the issue.