### PR TITLE
feat: add Unix socket support

### DIFF
--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -24,6 +24,8 @@ Run `nx test providers-flagd` to execute the unit tests via [Jest](https://jestj
 
 The `FlagdProvider` client constructor takes a single optional argument with 3 fields, their default values correspond to the default arguments supplied to the flagd server:
 
+### Example using TCP
+
 ```
   OpenFeature.setProvider(new FlagdProvider({
       host: 'localhost',
@@ -32,6 +34,16 @@ The `FlagdProvider` client constructor takes a single optional argument with 3 f
   }))
 ```
 
+### Example using a Unix socket
+
+```
+  OpenFeature.setProvider(new FlagdProvider({
+      socketPath: "/tmp/flagd.socks",
+  }))
+```
+
+**service**: "http" | "grpc" _(defaults to http)_  
 **host**: string _(defaults to "localhost")_  
 **port**: number _(defaults to 8013)_  
 **protocol**: "http" | "https" _(defaults to http - only active for http service)_
+**socketPath**: string _(optional and only applies when using grpc)_

--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -46,4 +46,4 @@ The `FlagdProvider` client constructor takes a single optional argument with 3 f
 **host**: string _(defaults to "localhost")_  
 **port**: number _(defaults to 8013)_  
 **protocol**: "http" | "https" _(defaults to http - only active for http service)_
-**socketPath**: string _(optional and only applies when using grpc)_
+**socketPath**: string _(optional)_

--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -1,10 +1,9 @@
-import {
-  Client, OpenFeature, ErrorCode
-} from '@openfeature/nodejs-sdk';
-import type { UnaryCall } from "@protobuf-ts/runtime-rpc";
+import { Client, OpenFeature, ErrorCode } from '@openfeature/nodejs-sdk';
+import type { UnaryCall } from '@protobuf-ts/runtime-rpc';
 import { Struct } from '../proto/ts/google/protobuf/struct';
 import { ServiceClient } from '../proto/ts/schema/v1/schema.client';
-import { ResolveBooleanRequest,
+import {
+  ResolveBooleanRequest,
   ResolveBooleanResponse,
   ResolveFloatRequest,
   ResolveFloatResponse,
@@ -13,7 +12,8 @@ import { ResolveBooleanRequest,
   ResolveObjectRequest,
   ResolveObjectResponse,
   ResolveStringRequest,
-  ResolveStringResponse } from '../proto/ts/schema/v1/schema';
+  ResolveStringResponse,
+} from '../proto/ts/schema/v1/schema';
 import { FlagdProvider } from './flagd-provider';
 import { GRPCService } from './service/grpc/service';
 
@@ -36,105 +36,179 @@ const OBJECT_KEY = 'object-flag';
 const OBJECT_VARIANT = 'obj';
 const OBJECT_INNER_KEY = 'inner-key';
 const OBJECT_INNER_VALUE = 'inner-val';
-const OBJECT_VALUE = Struct.fromJson({[OBJECT_INNER_KEY]: OBJECT_INNER_VALUE});
+const OBJECT_VALUE = Struct.fromJson({
+  [OBJECT_INNER_KEY]: OBJECT_INNER_VALUE,
+});
 
 const TEST_CONTEXT_KEY = 'context-key';
 const TEST_CONTEXT_VALUE = 'context-value';
 const TEST_CONTEXT = { [TEST_CONTEXT_KEY]: TEST_CONTEXT_VALUE };
-const TEST_CONTEXT_CONVERTED = Struct.fromJsonString(JSON.stringify(TEST_CONTEXT));
+const TEST_CONTEXT_CONVERTED = Struct.fromJsonString(
+  JSON.stringify(TEST_CONTEXT)
+);
+
+jest.mock('@protobuf-ts/grpc-transport');
+
+import { GrpcTransport } from '@protobuf-ts/grpc-transport';
 
 describe(FlagdProvider.name, () => {
+  describe('GRPC Service Options', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should use a unix socket', () => {
+      new FlagdProvider({ socketPath: '/tmp/flagd.sock' });
+      expect(GrpcTransport).toHaveBeenCalledWith(
+        expect.objectContaining({ host: 'unix:///tmp/flagd.sock' })
+      );
+    });
+
+    it('should use a host and port', () => {
+      new FlagdProvider();
+      expect(GrpcTransport).toHaveBeenCalledWith(
+        expect.objectContaining({ host: 'localhost:8013' })
+      );
+    });
+  });
 
   describe('basic flag resolution', () => {
     let client: Client;
 
     // mock ServiceClient to inject
     const basicServiceClientMock: ServiceClient = {
-      resolveBoolean: jest.fn((): UnaryCall<ResolveBooleanRequest, ResolveBooleanResponse> => {
-        return Promise.resolve({
-          request: {} as ResolveBooleanRequest,
-          response: {
-            value: BOOLEAN_VALUE,
-            variant: BOOLEAN_VARIANT,
-            reason: REASON
-          },
-        }) as unknown as UnaryCall<ResolveBooleanRequest, ResolveBooleanResponse>
-      }),
-      resolveString: jest.fn((): UnaryCall<ResolveStringRequest, ResolveStringResponse> => {
-        return Promise.resolve({
-          request: {} as ResolveStringRequest,
-          response: {
-            value: STRING_VALUE,
-            variant: STRING_VARIANT,
-            reason: REASON
-          } as ResolveStringResponse,
-        }) as unknown as UnaryCall<ResolveStringRequest, ResolveStringResponse>
-      }),
-      resolveFloat: jest.fn((): UnaryCall<ResolveFloatRequest, ResolveFloatResponse> => {
-        return Promise.resolve({
-          request: {} as ResolveFloatRequest,
-          response: {
-            value: NUMBER_VALUE,
-            variant: NUMBER_VARIANT,
-            reason: REASON
-          } as ResolveFloatResponse,
-        }) as unknown as UnaryCall<ResolveFloatRequest, ResolveFloatResponse>
-      }),
-      resolveInt: jest.fn((): UnaryCall<ResolveIntRequest, ResolveIntResponse> => {
-        throw new Error('resolveInt should not be called'); // we never call this method, we resolveFloat for all numbers.
-      }),
-      resolveObject: jest.fn((): UnaryCall<ResolveObjectRequest, ResolveObjectResponse> => {
-        return Promise.resolve({
-          request: {} as ResolveObjectRequest,
-          response: {
-            value: OBJECT_VALUE,
-            variant: OBJECT_VARIANT,
-            reason: REASON
-          } as ResolveObjectResponse,
-        }) as unknown as UnaryCall<ResolveObjectRequest, ResolveObjectResponse>
-      })
+      resolveBoolean: jest.fn(
+        (): UnaryCall<ResolveBooleanRequest, ResolveBooleanResponse> => {
+          return Promise.resolve({
+            request: {} as ResolveBooleanRequest,
+            response: {
+              value: BOOLEAN_VALUE,
+              variant: BOOLEAN_VARIANT,
+              reason: REASON,
+            },
+          }) as unknown as UnaryCall<
+            ResolveBooleanRequest,
+            ResolveBooleanResponse
+          >;
+        }
+      ),
+      resolveString: jest.fn(
+        (): UnaryCall<ResolveStringRequest, ResolveStringResponse> => {
+          return Promise.resolve({
+            request: {} as ResolveStringRequest,
+            response: {
+              value: STRING_VALUE,
+              variant: STRING_VARIANT,
+              reason: REASON,
+            } as ResolveStringResponse,
+          }) as unknown as UnaryCall<
+            ResolveStringRequest,
+            ResolveStringResponse
+          >;
+        }
+      ),
+      resolveFloat: jest.fn(
+        (): UnaryCall<ResolveFloatRequest, ResolveFloatResponse> => {
+          return Promise.resolve({
+            request: {} as ResolveFloatRequest,
+            response: {
+              value: NUMBER_VALUE,
+              variant: NUMBER_VARIANT,
+              reason: REASON,
+            } as ResolveFloatResponse,
+          }) as unknown as UnaryCall<ResolveFloatRequest, ResolveFloatResponse>;
+        }
+      ),
+      resolveInt: jest.fn(
+        (): UnaryCall<ResolveIntRequest, ResolveIntResponse> => {
+          throw new Error('resolveInt should not be called'); // we never call this method, we resolveFloat for all numbers.
+        }
+      ),
+      resolveObject: jest.fn(
+        (): UnaryCall<ResolveObjectRequest, ResolveObjectResponse> => {
+          return Promise.resolve({
+            request: {} as ResolveObjectRequest,
+            response: {
+              value: OBJECT_VALUE,
+              variant: OBJECT_VARIANT,
+              reason: REASON,
+            } as ResolveObjectResponse,
+          }) as unknown as UnaryCall<
+            ResolveObjectRequest,
+            ResolveObjectResponse
+          >;
+        }
+      ),
     } as unknown as ServiceClient;
-  
+
     beforeEach(() => {
-       // inject our mock GRPCService and ServiceClient
-      OpenFeature.setProvider(new FlagdProvider(undefined, new GRPCService({ host: '', port: 123, protocol: 'http' }, basicServiceClientMock)));
+      // inject our mock GRPCService and ServiceClient
+      OpenFeature.setProvider(
+        new FlagdProvider(
+          undefined,
+          new GRPCService(
+            { host: '', port: 123, protocol: 'http' },
+            basicServiceClientMock
+          )
+        )
+      );
       client = OpenFeature.getClient('test');
     });
-  
+
     describe(FlagdProvider.prototype.resolveBooleanEvaluation.name, () => {
       it(`should call ${ServiceClient.prototype.resolveBoolean} with key and context and return details`, async () => {
-        const val = await client.getBooleanDetails(BOOLEAN_KEY, false, TEST_CONTEXT);
-        expect(basicServiceClientMock.resolveBoolean).toHaveBeenCalledWith({flagKey: BOOLEAN_KEY, context: TEST_CONTEXT_CONVERTED});
+        const val = await client.getBooleanDetails(
+          BOOLEAN_KEY,
+          false,
+          TEST_CONTEXT
+        );
+        expect(basicServiceClientMock.resolveBoolean).toHaveBeenCalledWith({
+          flagKey: BOOLEAN_KEY,
+          context: TEST_CONTEXT_CONVERTED,
+        });
         expect(val.value).toEqual(BOOLEAN_VALUE);
         expect(val.variant).toEqual(BOOLEAN_VARIANT);
         expect(val.reason).toEqual(REASON);
       });
     });
-  
+
     describe(FlagdProvider.prototype.resolveStringEvaluation.name, () => {
       it(`should call ${ServiceClient.prototype.resolveString} with key and context and return details`, async () => {
-        const val = await client.getStringDetails(STRING_KEY, 'nope', TEST_CONTEXT);
-        expect(basicServiceClientMock.resolveString).toHaveBeenCalledWith({flagKey: STRING_KEY, context: TEST_CONTEXT_CONVERTED});
+        const val = await client.getStringDetails(
+          STRING_KEY,
+          'nope',
+          TEST_CONTEXT
+        );
+        expect(basicServiceClientMock.resolveString).toHaveBeenCalledWith({
+          flagKey: STRING_KEY,
+          context: TEST_CONTEXT_CONVERTED,
+        });
         expect(val.value).toEqual(STRING_VALUE);
         expect(val.variant).toEqual(STRING_VARIANT);
         expect(val.reason).toEqual(REASON);
       });
     });
-  
+
     describe(FlagdProvider.prototype.resolveNumberEvaluation.name, () => {
       it(`should call ${ServiceClient.prototype.resolveFloat} with key and context and return details`, async () => {
         const val = await client.getNumberDetails(NUMBER_KEY, 0, TEST_CONTEXT);
-        expect(basicServiceClientMock.resolveFloat).toHaveBeenCalledWith({flagKey: NUMBER_KEY, context: TEST_CONTEXT_CONVERTED});
+        expect(basicServiceClientMock.resolveFloat).toHaveBeenCalledWith({
+          flagKey: NUMBER_KEY,
+          context: TEST_CONTEXT_CONVERTED,
+        });
         expect(val.value).toEqual(NUMBER_VALUE);
         expect(val.variant).toEqual(NUMBER_VARIANT);
         expect(val.reason).toEqual(REASON);
       });
     });
-  
+
     describe(FlagdProvider.prototype.resolveObjectEvaluation.name, () => {
       it(`should call ${ServiceClient.prototype.resolveObject} with key and context and return details`, async () => {
         const val = await client.getObjectDetails(OBJECT_KEY, {}, TEST_CONTEXT);
-        expect(basicServiceClientMock.resolveObject).toHaveBeenCalledWith({flagKey: OBJECT_KEY, context: TEST_CONTEXT_CONVERTED});
+        expect(basicServiceClientMock.resolveObject).toHaveBeenCalledWith({
+          flagKey: OBJECT_KEY,
+          context: TEST_CONTEXT_CONVERTED,
+        });
         expect(val.value).toEqual({ [OBJECT_INNER_KEY]: OBJECT_INNER_VALUE });
         expect(val.variant).toEqual(OBJECT_VARIANT);
         expect(val.reason).toEqual(REASON);
@@ -145,47 +219,74 @@ describe(FlagdProvider.name, () => {
   describe('resolution errors', () => {
     const errorResponsePartial = {
       reason: ERROR_REASON,
-    }
+    };
 
     let client: Client;
 
     // mock ServiceClient to inject
     const errServiceClientMock: ServiceClient = {
-      resolveBoolean: jest.fn((): UnaryCall<ResolveBooleanRequest, ResolveBooleanResponse> => {
-        return Promise.reject({
-          request: {} as ResolveBooleanRequest,
-          response: errorResponsePartial,
-        }) as unknown as UnaryCall<ResolveBooleanRequest, ResolveBooleanResponse>
-      }),
-      resolveString: jest.fn((): UnaryCall<ResolveStringRequest, ResolveStringResponse> => {
-        return Promise.reject({
-          request: {} as ResolveStringRequest,
-          response: errorResponsePartial as ResolveStringResponse,
-        }) as unknown as UnaryCall<ResolveStringRequest, ResolveStringResponse>
-      }),
-      resolveFloat: jest.fn((): UnaryCall<ResolveFloatRequest, ResolveFloatResponse> => {
-        return Promise.reject({
-          request: {} as ResolveFloatRequest,
-          response: errorResponsePartial as ResolveFloatResponse,
-        }) as unknown as UnaryCall<ResolveFloatRequest, ResolveFloatResponse>
-      }),
-      resolveInt: jest.fn((): UnaryCall<ResolveIntRequest, ResolveIntResponse> => {
-        throw new Error('resolveInt should not be called'); // we never call this method, we resolveFloat for all numbers.
-      }),
-      resolveObject: jest.fn((): UnaryCall<ResolveObjectRequest, ResolveObjectResponse> => {
-        return Promise.reject({
-          request: {} as ResolveObjectRequest,
-          response: errorResponsePartial as ResolveObjectResponse,
-        }) as unknown as UnaryCall<ResolveObjectRequest, ResolveObjectResponse>
-      })
+      resolveBoolean: jest.fn(
+        (): UnaryCall<ResolveBooleanRequest, ResolveBooleanResponse> => {
+          return Promise.reject({
+            request: {} as ResolveBooleanRequest,
+            response: errorResponsePartial,
+          }) as unknown as UnaryCall<
+            ResolveBooleanRequest,
+            ResolveBooleanResponse
+          >;
+        }
+      ),
+      resolveString: jest.fn(
+        (): UnaryCall<ResolveStringRequest, ResolveStringResponse> => {
+          return Promise.reject({
+            request: {} as ResolveStringRequest,
+            response: errorResponsePartial as ResolveStringResponse,
+          }) as unknown as UnaryCall<
+            ResolveStringRequest,
+            ResolveStringResponse
+          >;
+        }
+      ),
+      resolveFloat: jest.fn(
+        (): UnaryCall<ResolveFloatRequest, ResolveFloatResponse> => {
+          return Promise.reject({
+            request: {} as ResolveFloatRequest,
+            response: errorResponsePartial as ResolveFloatResponse,
+          }) as unknown as UnaryCall<ResolveFloatRequest, ResolveFloatResponse>;
+        }
+      ),
+      resolveInt: jest.fn(
+        (): UnaryCall<ResolveIntRequest, ResolveIntResponse> => {
+          throw new Error('resolveInt should not be called'); // we never call this method, we resolveFloat for all numbers.
+        }
+      ),
+      resolveObject: jest.fn(
+        (): UnaryCall<ResolveObjectRequest, ResolveObjectResponse> => {
+          return Promise.reject({
+            request: {} as ResolveObjectRequest,
+            response: errorResponsePartial as ResolveObjectResponse,
+          }) as unknown as UnaryCall<
+            ResolveObjectRequest,
+            ResolveObjectResponse
+          >;
+        }
+      ),
     } as unknown as ServiceClient;
-  
+
     beforeEach(() => {
       // inject our mock GRPCService and ServiceClient
-      OpenFeature.setProvider(new FlagdProvider(undefined, new GRPCService({ host: '', port: 123, protocol: 'http' }, errServiceClientMock)));
+      OpenFeature.setProvider(
+        new FlagdProvider(
+          undefined,
+          new GRPCService(
+            { host: '', port: 123, protocol: 'http' },
+            errServiceClientMock
+          )
+        )
+      );
       client = OpenFeature.getClient('test');
     });
-  
+
     describe(FlagdProvider.prototype.resolveBooleanEvaluation.name, () => {
       const DEFAULT = false;
 
@@ -196,7 +297,7 @@ describe(FlagdProvider.name, () => {
         expect(val.reason).toEqual(ERROR_REASON);
       });
     });
-  
+
     describe(FlagdProvider.prototype.resolveStringEvaluation.name, () => {
       const DEFAULT = 'nope';
 
@@ -207,9 +308,9 @@ describe(FlagdProvider.name, () => {
         expect(val.reason).toEqual(ERROR_REASON);
       });
     });
-  
+
     describe(FlagdProvider.prototype.resolveNumberEvaluation.name, () => {
-      const DEFAULT = 0
+      const DEFAULT = 0;
 
       it('should default', async () => {
         const val = await client.getNumberDetails(NUMBER_KEY, DEFAULT);
@@ -218,14 +319,15 @@ describe(FlagdProvider.name, () => {
         expect(val.reason).toEqual(ERROR_REASON);
       });
     });
-  
-    describe(FlagdProvider.prototype.resolveObjectEvaluation.name, () => {
 
+    describe(FlagdProvider.prototype.resolveObjectEvaluation.name, () => {
       const DEFAULT_INNER_KEY = 'uh';
       const DEFAULT_INNER_VALUE = 'oh';
 
       it('should default', async () => {
-        const val = await client.getObjectDetails(OBJECT_KEY, { [DEFAULT_INNER_KEY]: DEFAULT_INNER_VALUE });
+        const val = await client.getObjectDetails(OBJECT_KEY, {
+          [DEFAULT_INNER_KEY]: DEFAULT_INNER_VALUE,
+        });
         expect(errServiceClientMock.resolveObject).toHaveBeenCalled();
         expect(val.value).toEqual({ [DEFAULT_INNER_KEY]: DEFAULT_INNER_VALUE });
         expect(val.reason).toEqual(ERROR_REASON);
@@ -238,30 +340,44 @@ describe(FlagdProvider.name, () => {
 
     // mock ServiceClient to inject
     const undefinedObjectMock: ServiceClient = {
-      resolveObject: jest.fn((): UnaryCall<ResolveObjectRequest, ResolveObjectResponse> => {
-        return Promise.resolve({
-          request: {} as ResolveObjectRequest,
-          response: {
-            value: undefined,
-            reason: REASON
-          } as ResolveObjectResponse,
-        }) as unknown as UnaryCall<ResolveObjectRequest, ResolveObjectResponse>
-      })
+      resolveObject: jest.fn(
+        (): UnaryCall<ResolveObjectRequest, ResolveObjectResponse> => {
+          return Promise.resolve({
+            request: {} as ResolveObjectRequest,
+            response: {
+              value: undefined,
+              reason: REASON,
+            } as ResolveObjectResponse,
+          }) as unknown as UnaryCall<
+            ResolveObjectRequest,
+            ResolveObjectResponse
+          >;
+        }
+      ),
     } as unknown as ServiceClient;
-  
+
     beforeEach(() => {
       // inject our mock GRPCService and ServiceClient
-      OpenFeature.setProvider(new FlagdProvider(undefined, new GRPCService({ host: '', port: 123, protocol: 'http' }, undefinedObjectMock)));
+      OpenFeature.setProvider(
+        new FlagdProvider(
+          undefined,
+          new GRPCService(
+            { host: '', port: 123, protocol: 'http' },
+            undefinedObjectMock
+          )
+        )
+      );
       client = OpenFeature.getClient('test');
     });
-  
-    describe(FlagdProvider.prototype.resolveObjectEvaluation.name, () => {
 
+    describe(FlagdProvider.prototype.resolveObjectEvaluation.name, () => {
       const DEFAULT_INNER_KEY = 'some';
       const DEFAULT_INNER_VALUE = 'key';
 
       it('should default and throw correct error', async () => {
-        const val = await client.getObjectDetails(OBJECT_KEY, { [DEFAULT_INNER_KEY]: DEFAULT_INNER_VALUE });
+        const val = await client.getObjectDetails(OBJECT_KEY, {
+          [DEFAULT_INNER_KEY]: DEFAULT_INNER_VALUE,
+        });
         expect(undefinedObjectMock.resolveObject).toHaveBeenCalled();
         expect(val.value).toEqual({ [DEFAULT_INNER_KEY]: DEFAULT_INNER_VALUE });
         expect(val.reason).toEqual(ERROR_REASON);

--- a/libs/providers/flagd/src/lib/flagd-provider.spec.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.spec.ts
@@ -1,7 +1,9 @@
-import { Client, OpenFeature, ErrorCode } from '@openfeature/nodejs-sdk';
+jest.mock('@protobuf-ts/grpc-transport');
+
+import { Client, ErrorCode, OpenFeature } from '@openfeature/nodejs-sdk';
+import { GrpcTransport } from '@protobuf-ts/grpc-transport';
 import type { UnaryCall } from '@protobuf-ts/runtime-rpc';
 import { Struct } from '../proto/ts/google/protobuf/struct';
-import { ServiceClient } from '../proto/ts/schema/v1/schema.client';
 import {
   ResolveBooleanRequest,
   ResolveBooleanResponse,
@@ -14,6 +16,7 @@ import {
   ResolveStringRequest,
   ResolveStringResponse,
 } from '../proto/ts/schema/v1/schema';
+import { ServiceClient } from '../proto/ts/schema/v1/schema.client';
 import { FlagdProvider } from './flagd-provider';
 import { GRPCService } from './service/grpc/service';
 
@@ -46,10 +49,6 @@ const TEST_CONTEXT = { [TEST_CONTEXT_KEY]: TEST_CONTEXT_VALUE };
 const TEST_CONTEXT_CONVERTED = Struct.fromJsonString(
   JSON.stringify(TEST_CONTEXT)
 );
-
-jest.mock('@protobuf-ts/grpc-transport');
-
-import { GrpcTransport } from '@protobuf-ts/grpc-transport';
 
 describe(FlagdProvider.name, () => {
   describe('GRPC Service Options', () => {

--- a/libs/providers/flagd/src/lib/flagd-provider.ts
+++ b/libs/providers/flagd/src/lib/flagd-provider.ts
@@ -10,7 +10,14 @@ import { Protocol } from './service/grpc/protocol';
 export interface FlagdProviderOptions {
   host?: string;
   port?: number;
+  // Should this be called protocol?
   protocol?: Protocol;
+  /**
+   * When set, a unix socket connection is used.
+   *
+   * @example "/tmp/flagd.socks"
+   */
+  socketPath?: string;
 }
 
 export class FlagdProvider implements Provider {
@@ -20,62 +27,53 @@ export class FlagdProvider implements Provider {
 
   private readonly service: Service;
 
-  constructor(options?: FlagdProviderOptions, service?: GRPCService) {
-    const { host, port, protocol }: FlagdProviderOptions = {
+  constructor(options?: FlagdProviderOptions, service?: Service) {
+    const { host, port, protocol, socketPath }: FlagdProviderOptions = {
       host: 'localhost',
       port: 8013,
       protocol: 'http',
       ...options,
     };
 
-    this.service = service ? service : new GRPCService({
-      host,
-      port,
-      protocol,
-    });
+    this.service = service
+      ? service
+      : new GRPCService({
+          host,
+          port,
+          protocol,
+          socketPath,
+        });
   }
 
   resolveBooleanEvaluation(
     flagKey: string,
-    defaultValue: boolean,
+    _: boolean,
     transformedContext: EvaluationContext
   ): Promise<ResolutionDetails<boolean>> {
-    return this.service.resolveBoolean(
-      flagKey,
-      transformedContext
-    );
+    return this.service.resolveBoolean(flagKey, transformedContext);
   }
 
   resolveStringEvaluation(
     flagKey: string,
-    defaultValue: string,
+    _: string,
     transformedContext: EvaluationContext
   ): Promise<ResolutionDetails<string>> {
-    return this.service.resolveString(
-      flagKey,
-      transformedContext
-    );
+    return this.service.resolveString(flagKey, transformedContext);
   }
 
   resolveNumberEvaluation(
     flagKey: string,
-    defaultValue: number,
+    _: number,
     transformedContext: EvaluationContext
   ): Promise<ResolutionDetails<number>> {
-    return this.service.resolveNumber(
-      flagKey,
-      transformedContext
-    );
+    return this.service.resolveNumber(flagKey, transformedContext);
   }
 
   resolveObjectEvaluation<U extends object>(
     flagKey: string,
-    defaultValue: U,
+    _: U,
     transformedContext: EvaluationContext
   ): Promise<ResolutionDetails<U>> {
-    return this.service.resolveObject(
-      flagKey,
-      transformedContext
-    );
+    return this.service.resolveObject(flagKey, transformedContext);
   }
 }

--- a/libs/providers/flagd/src/lib/service/grpc/service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/service.ts
@@ -1,6 +1,8 @@
 import * as grpc from '@grpc/grpc-js';
 import {
-  EvaluationContext, ParseError, ResolutionDetails
+  EvaluationContext,
+  ParseError,
+  ResolutionDetails,
 } from '@openfeature/nodejs-sdk';
 import { GrpcTransport } from '@protobuf-ts/grpc-transport';
 import { JsonObject } from '@protobuf-ts/runtime';
@@ -12,20 +14,26 @@ import { Protocol } from './protocol';
 interface GRPCServiceOptions {
   host: string;
   port: number;
-  protocol: Protocol
+  protocol: Protocol;
+  socketPath?: string;
 }
 
 export class GRPCService implements Service {
   client: ServiceClient;
 
   constructor(options: GRPCServiceOptions, client?: ServiceClient) {
-    const { host, port, protocol } = options;
-    this.client = client ? client : new ServiceClient(
-      new GrpcTransport({
-        host: `${host}:${port}`,
-        channelCredentials: protocol === 'http' ? grpc.credentials.createInsecure() : grpc.credentials.createSsl()
-      })
-    );
+    const { host, port, protocol, socketPath } = options;
+    this.client = client
+      ? client
+      : new ServiceClient(
+          new GrpcTransport({
+            host: socketPath ? `unix://${socketPath}` : `${host}:${port}`,
+            channelCredentials:
+              protocol === 'http'
+                ? grpc.credentials.createInsecure()
+                : grpc.credentials.createSsl(),
+          })
+        );
   }
 
   async resolveBoolean(
@@ -99,5 +107,5 @@ export class GRPCService implements Service {
     } catch (e) {
       throw new ParseError(`Error serializing context.`);
     }
-  } 
+  }
 }


### PR DESCRIPTION
This PR adds support for Unix sockets when using gRPC.

I did notice a few items that should be discussed and addressed in a future PR.

- [x] HTTP is used by default but it should likely be gRPC
- [x] Consider completely removing HTTP since it requires additional dependencies.
- [ ] Include environment variable support in flagd

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>