### PR TITLE
chore: relax @grpc/grpc-js peer version

### DIFF
--- a/libs/providers/flagd/package.json
+++ b/libs/providers/flagd/package.json
@@ -9,7 +9,7 @@
     "@openfeature/flagd-core": ">=0.1.1"
   },
   "peerDependencies": {
-    "@grpc/grpc-js": "~1.8.0",
+    "@grpc/grpc-js": "^1.8.0",
     "@openfeature/server-sdk": ">=1.6.0"
   }
 }


### PR DESCRIPTION
Relaxing this dep version now that [this](https://github.com/grpc/grpc-node/issues/2620#issuecomment-1828453764) is resolved.