### PR TITLE
feat: Implement gRPC keepAlive param (#1288)

### DIFF
--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -40,6 +40,7 @@ Options can be defined in the constructor or as environment variables. Construct
 | cache                                  | FLAGD_CACHE                    | string  | lru                                                            | lru, disabled    |
 | maxCacheSize                           | FLAGD_MAX_CACHE_SIZE           | int     | 1000                                                           |                  |
 | defaultAuthority                       | FLAGD_DEFAULT_AUTHORITY        | string  | -                                                              | rpc, in-process  |
+| keepAliveTime                            | FLAGD_KEEP_ALIVE_TIME_MS       | number  | 0                                                              | rpc, in-process  |
 
 #### Resolver type-specific Defaults
 
@@ -104,6 +105,19 @@ Please refer to this [GitHub issue](https://github.com/open-feature/js-sdk-contr
   OpenFeature.setProvider(new FlagdProvider({
       resolverType: 'in-process',
       defaultAuthority: 'b-target-api.service',
+  }))
+```
+
+### Keepalive Configuration (optional)
+
+gRPC keepalive prevents idle connections from being closed.
+This option only applies to RPC and in-process resolvers (streaming connections).
+Set to `0` to disable keepalive (default).
+
+```ts
+  OpenFeature.setProvider(new FlagdProvider({
+      resolverType: 'in-process',
+      keepAliveTime: 30000, // Send keepalive ping every 30 seconds
   }))
 ```
 

--- a/libs/providers/flagd/src/lib/configuration.spec.ts
+++ b/libs/providers/flagd/src/lib/configuration.spec.ts
@@ -26,6 +26,7 @@ describe('Configuration', () => {
       selector: '',
       deadlineMs: 500,
       contextEnricher: expect.any(Function),
+      keepAliveTime: 0,
     });
   });
 
@@ -41,6 +42,7 @@ describe('Configuration', () => {
     const selector = 'app=weather';
     const offlineFlagSourcePath = '/tmp/flags.json';
     const defaultAuthority = 'test-authority';
+    const keepAliveTime = 30000;
 
     process.env['FLAGD_HOST'] = host;
     process.env['FLAGD_PORT'] = `${port}`;
@@ -53,6 +55,7 @@ describe('Configuration', () => {
     process.env['FLAGD_RESOLVER'] = `${resolverType}`;
     process.env['FLAGD_OFFLINE_FLAG_SOURCE_PATH'] = offlineFlagSourcePath;
     process.env['FLAGD_DEFAULT_AUTHORITY'] = defaultAuthority;
+    process.env['FLAGD_KEEP_ALIVE_TIME_MS'] = `${keepAliveTime}`;
 
     expect(getConfig()).toEqual(
       expect.objectContaining({
@@ -68,6 +71,7 @@ describe('Configuration', () => {
         offlineFlagSourcePath,
         defaultAuthority,
         deadlineMs: 500,
+        keepAliveTime,
       }),
     );
   });
@@ -114,6 +118,7 @@ describe('Configuration', () => {
       defaultAuthority: '',
       deadlineMs: 500,
       contextEnricher: contextEnricher,
+      keepAliveTime: 30000,
     };
 
     process.env['FLAGD_HOST'] = 'override';
@@ -122,6 +127,7 @@ describe('Configuration', () => {
     process.env['FLAGD_TLS'] = 'false';
     process.env['FLAGD_SERVER_CERT_PATH'] = '/env/cert.pem';
     process.env['FLAGD_DEFAULT_AUTHORITY'] = 'test-authority-override';
+    process.env['FLAGD_KEEP_ALIVE_TIME_MS'] = '30000';
 
     expect(getConfig(options)).toStrictEqual(options);
   });

--- a/libs/providers/flagd/src/lib/configuration.ts
+++ b/libs/providers/flagd/src/lib/configuration.ts
@@ -89,6 +89,14 @@ export interface Config {
    *
    */
   defaultAuthority?: string;
+
+  /**
+   * gRPC client KeepAlive in milliseconds. Disabled with 0.
+   * Only applies to RPC and in-process resolvers.
+   *
+   * @default 0
+   */
+  keepAliveTime?: number;
 }
 
 interface FlagdConfig extends Config {
@@ -114,6 +122,7 @@ const DEFAULT_CONFIG: Omit<FlagdConfig, 'port' | 'resolverType'> = {
   cache: 'lru',
   maxCacheSize: DEFAULT_MAX_CACHE_SIZE,
   contextEnricher: (syncContext: EvaluationContext | null) => syncContext ?? {},
+  keepAliveTime: 0,
 };
 
 const DEFAULT_RPC_CONFIG: FlagdConfig = { ...DEFAULT_CONFIG, resolverType: 'rpc', port: 8013 };
@@ -134,6 +143,7 @@ enum ENV_VAR {
   FLAGD_RESOLVER = 'FLAGD_RESOLVER',
   FLAGD_OFFLINE_FLAG_SOURCE_PATH = 'FLAGD_OFFLINE_FLAG_SOURCE_PATH',
   FLAGD_DEFAULT_AUTHORITY = 'FLAGD_DEFAULT_AUTHORITY',
+  FLAGD_KEEP_ALIVE_TIME_MS = 'FLAGD_KEEP_ALIVE_TIME_MS',
 }
 
 function checkEnvVarResolverType() {
@@ -193,6 +203,9 @@ const getEnvVarConfig = (): Partial<Config> => {
     }),
     ...(process.env[ENV_VAR.FLAGD_DEFAULT_AUTHORITY] && {
       defaultAuthority: process.env[ENV_VAR.FLAGD_DEFAULT_AUTHORITY],
+    }),
+    ...(Number(process.env[ENV_VAR.FLAGD_KEEP_ALIVE_TIME_MS]) && {
+      keepAliveTime: Number(process.env[ENV_VAR.FLAGD_KEEP_ALIVE_TIME_MS]),
     }),
   };
 };

--- a/libs/providers/flagd/src/lib/service/common/grpc-util.spec.ts
+++ b/libs/providers/flagd/src/lib/service/common/grpc-util.spec.ts
@@ -1,0 +1,45 @@
+import { buildClientOptions } from './grpc-util';
+import type { Config } from '../../configuration';
+
+describe('buildClientOptions', () => {
+  const baseConfig: Config = {
+    host: 'localhost',
+    port: 8013,
+    tls: false,
+    deadlineMs: 500,
+    socketPath: '',
+  };
+
+  it('should return undefined when no relevant options are set', () => {
+    expect(buildClientOptions(baseConfig)).toBeUndefined();
+  });
+
+  it.each([
+    {
+      configKey: 'defaultAuthority',
+      value: 'test-authority',
+      grpcKey: 'grpc.default_authority',
+      expected: 'test-authority',
+    },
+    { configKey: 'keepAliveTime', value: 10000, grpcKey: 'grpc.keepalive_time_ms', expected: 10000 },
+  ])('should include $configKey when set to valid value', ({ configKey, value, grpcKey, expected }) => {
+    const config = { ...baseConfig, [configKey]: value };
+    expect(buildClientOptions(config)).toEqual({ [grpcKey]: expected });
+  });
+
+  it.each([
+    { configKey: 'keepAliveTime', value: 0, description: 'zero' },
+    { configKey: 'keepAliveTime', value: -1, description: 'negative' },
+  ])('should exclude $configKey when $description', ({ configKey, value }) => {
+    const config = { ...baseConfig, [configKey]: value };
+    expect(buildClientOptions(config)).toBeUndefined();
+  });
+
+  it('should combine multiple options', () => {
+    const config: Config = { ...baseConfig, defaultAuthority: 'my-authority', keepAliveTime: 5000 };
+    expect(buildClientOptions(config)).toEqual({
+      'grpc.default_authority': 'my-authority',
+      'grpc.keepalive_time_ms': 5000,
+    });
+  });
+});

--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -30,7 +30,7 @@ import type { Config } from '../../configuration';
 import { DEFAULT_MAX_CACHE_SIZE, EVENT_CONFIGURATION_CHANGE, EVENT_PROVIDER_READY } from '../../constants';
 import { FlagdProvider } from '../../flagd-provider';
 import type { Service } from '../service';
-import { closeStreamIfDefined, createChannelCredentials } from '../common';
+import { buildClientOptions, closeStreamIfDefined, createChannelCredentials } from '../common';
 
 type AnyResponse =
   | ResolveBooleanResponse
@@ -80,14 +80,8 @@ export class GRPCService implements Service {
     client?: ServiceClient,
     private logger?: Logger,
   ) {
-    const { host, port, tls, socketPath, certPath, defaultAuthority } = config;
-    let clientOptions: ClientOptions | undefined;
-    if (defaultAuthority) {
-      clientOptions = {
-        'grpc.default_authority': defaultAuthority,
-      };
-    }
-
+    const { host, port, tls, socketPath, certPath } = config;
+    const clientOptions = buildClientOptions(config);
     const channelCredentials = createChannelCredentials(tls, certPath);
 
     this._client = client

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
@@ -1,10 +1,10 @@
-import type { ClientReadableStream, ServiceError, ClientOptions } from '@grpc/grpc-js';
+import type { ClientReadableStream, ServiceError } from '@grpc/grpc-js';
 import type { EvaluationContext, Logger } from '@openfeature/server-sdk';
 import { GeneralError } from '@openfeature/server-sdk';
 import type { SyncFlagsRequest, SyncFlagsResponse } from '../../../../proto/ts/flagd/sync/v1/sync';
 import { FlagSyncServiceClient } from '../../../../proto/ts/flagd/sync/v1/sync';
 import type { Config } from '../../../configuration';
-import { closeStreamIfDefined, createChannelCredentials } from '../../common';
+import { buildClientOptions, closeStreamIfDefined, createChannelCredentials } from '../../common';
 import type { DataFetch } from '../data-fetch';
 
 /**
@@ -35,14 +35,8 @@ export class GrpcFetch implements DataFetch {
     syncServiceClient?: FlagSyncServiceClient,
     logger?: Logger,
   ) {
-    const { host, port, tls, socketPath, certPath, selector, defaultAuthority } = config;
-    let clientOptions: ClientOptions | undefined;
-    if (defaultAuthority) {
-      clientOptions = {
-        'grpc.default_authority': defaultAuthority,
-      };
-    }
-
+    const { host, port, tls, socketPath, certPath, selector } = config;
+    const clientOptions = buildClientOptions(config);
     const channelCredentials = createChannelCredentials(tls, certPath);
 
     this._syncClient = syncServiceClient


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This PR implements keepAlive param for gRPC

- adds keepAlive param for RPC and in-process
- adds util function to build gRPC client options form config

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1288

### How to test
`npm run test`

