### PR TITLE
fix(go-feature-flag): Move wasm file outside of src

### DIFF
--- a/libs/providers/go-feature-flag/project.json
+++ b/libs/providers/go-feature-flag/project.json
@@ -77,7 +77,7 @@
           {
             "glob": "**/*.wasm",
             "input": "./libs/providers/go-feature-flag/src/lib/wasm/wasm-module",
-            "output": "./src/lib/wasm/wasm-module"
+            "output": "./wasm-module"
           }
         ]
       }


### PR DESCRIPTION
Fixes pnpm wasm module not loaded issue by copying file to root location