### PR TITLE
chore: bump WASM to v0.1.3

### DIFF
--- a/libs/providers/go-feature-flag/scripts/copy-latest-wasm.js
+++ b/libs/providers/go-feature-flag/scripts/copy-latest-wasm.js
@@ -8,7 +8,7 @@ const { execSync } = require('child_process');
  * Script to copy the go-feature-flag WASM evaluation module
  * This replaces the hardcoded version approach with a configurable one
  */
-const TARGET_WASM_VERSION = 'v1.45.6';
+const TARGET_WASM_VERSION = "v0.1.3";
 
 function copyWasmFile() {
   try {


### PR DESCRIPTION
Automated pull request to bump the GO Feature Flag evaluation WASM version to v0.1.3.