### PR TITLE
feat: invalidate etag on context change

### DIFF
--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -133,6 +133,7 @@ export class OFREPWebProvider implements Provider {
    */
   async onContextChange(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void> {
     try {
+      this._etag = null; // reset etag to force refetch
       this._context = newContext;
 
       const now = new Date();


### PR DESCRIPTION
See: https://github.com/open-feature/flagd/pull/1858

We can do some very aggressive and efficient caching if we make this simple change, basically using the ETag to prevent re-evaluations (the server will send 304 unless the servers flag config has changed). But, after context changes, we need to remove this so that we force-reevaluation with the new context.

I'm not sure if we should spec this somehow, is there a spec somewhere for OFREP client providers?