### PR TITLE
chore: use npm oidc auth for publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+      - name: Update npm (for OIDC auth)
+        run: npm install -g npm@^11.5.1
       - name: Build Packages
         if: ${{ steps.release.outputs.releases_created }}
         run: |
@@ -46,5 +49,5 @@ jobs:
       - name: Publish to NPM
         if: ${{ steps.release.outputs.releases_created }}
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
         run: npm run publish


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Implements NPM OIDC auth for publishing similar to JS SDK. Also enables provenance. 

