### PR TITLE
fix: only install npm if setup-node ran

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: 'npm'
       - name: Update npm (for OIDC auth)
+        if: ${{ steps.release.outputs.releases_created }}
         run: npm install -g npm@^11.5.1
       - name: Build Packages
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Adds a missing `if:` to the NPM update added in #1468.
If no release is created, `setup-node` is not run. If that does not happen, the preinstalled node of the runner is used. 
Using the preinstalled `Node` does not work for global installs: https://github.com/open-feature/js-sdk-contrib/actions/runs/21828183599/job/62979082218#step:6:1

https://github.com/actions/runner-images/issues/9644#issuecomment-2041554588

