### PR TITLE
chore: add license information to package.json files

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,3 +1,4 @@
 {
-  "module": "commonjs"
+  "module": "commonjs",
+  "license": "Apache-2.0"
 }

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "@js-sdk-contrib/workspace-plugin",
   "version": "0.0.1",
   "type": "commonjs",
+  "license": "Apache-2.0",
   "generators": "./generators.json",
   "dependencies": {
     "@nx/devkit": "20.3.1",


### PR DESCRIPTION
Addresses #968 by adding the `Apache-2.0` license to `assets/package.json` and `tools/workspace-plugin/package.json`.