### PR TITLE
chore(go-feature-flag): linter issues: unused variable and check options validity.

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.test.ts
+++ b/libs/providers/go-feature-flag/src/lib/go-feature-flag-provider.test.ts
@@ -989,7 +989,7 @@ describe('GoFeatureFlagProvider', () => {
     it('Should change evaluation details if config has changed', async () => {
       jest.useRealTimers();
       let callCount = 0;
-      fetchMock.mockIf(/^http:\/\/localhost:1031\/v1\/flag\/configuration/, async (request) => {
+      fetchMock.mockIf(/^http:\/\/localhost:1031\/v1\/flag\/configuration/, async () => {
         callCount++;
         if (callCount <= 1) {
           return {

--- a/libs/providers/go-feature-flag/src/lib/service/api.ts
+++ b/libs/providers/go-feature-flag/src/lib/service/api.ts
@@ -41,7 +41,10 @@ export class GoFeatureFlagApi {
       throw new InvalidOptionsException('Options cannot be null');
     }
 
-    this.endpoint = options.endpoint!;
+    if (!options.endpoint || options.endpoint.trim() === '') {
+      throw new InvalidOptionsException('Endpoint cannot be null');
+    }
+    this.endpoint = options.endpoint.trim();
     this.timeout = options.timeout || 10000;
     this.apiKey = options.apiKey;
     this.fetchImplementation = options.fetchImplementation || isomorphicFetch();


### PR DESCRIPTION
linter issues:
- remove unused variable
- check endpoint options validity