### PR TITLE
fix: various custom operator conformance fixes

### DIFF
--- a/libs/providers/flagd/src/e2e/tests/in-process.spec.ts
+++ b/libs/providers/flagd/src/e2e/tests/in-process.spec.ts
@@ -25,7 +25,7 @@ describe('in-process', () => {
       // remove filters as we add support for features
       // see: https://github.com/open-feature/js-sdk-contrib/issues/1096 and child issues
       tagFilter:
-        '@in-process and not @targetURI and not @sync and not @unixsocket and not @deprecated and not @fractional-v1 and not @operator-errors',
+        '@in-process and not @targetURI and not @sync and not @unixsocket and not @deprecated and not @fractional-v1',
       scenarioNameTemplate: (vars) => {
         return `${vars.scenarioTitle} (${vars.scenarioTags.join(',')} ${vars.featureTags.join(',')})`;
       },

--- a/libs/providers/flagd/src/e2e/tests/rpc.spec.ts
+++ b/libs/providers/flagd/src/e2e/tests/rpc.spec.ts
@@ -25,7 +25,7 @@ describe('rpc', () => {
       tagFilter:
         // remove filters as we add support for features
         // see: https://github.com/open-feature/js-sdk-contrib/issues/1096 and child issues
-        '@rpc and not @targetURI and not @caching and not @unixsocket and not @deprecated and not @fractional-v1 and not @operator-errors',
+        '@rpc and not @targetURI and not @caching and not @unixsocket and not @deprecated and not @fractional-v1 and not @operator-errors and not @semver-edge-cases and not @evaluator-refs-whitespace and not @non-existent-evaluator-ref and not @fractional-single-entry',
       scenarioNameTemplate: (vars) => {
         return `${vars.scenarioTitle} (${vars.scenarioTags.join(',')} ${vars.featureTags.join(',')})`;
       },

--- a/libs/providers/flagd/src/e2e/tests/rpc.spec.ts
+++ b/libs/providers/flagd/src/e2e/tests/rpc.spec.ts
@@ -23,9 +23,7 @@ describe('rpc', () => {
   autoBindSteps(
     loadFeatures(GHERKIN_FLAGD, {
       tagFilter:
-        // remove filters as we add support for features
-        // see: https://github.com/open-feature/js-sdk-contrib/issues/1096 and child issues
-        '@rpc and not @targetURI and not @caching and not @unixsocket and not @deprecated and not @fractional-v1 and not @operator-errors and not @semver-edge-cases and not @evaluator-refs-whitespace and not @non-existent-evaluator-ref and not @fractional-single-entry',
+        '@rpc and not @targetURI and not @caching and not @unixsocket and not @deprecated and not @fractional-v1',
       scenarioNameTemplate: (vars) => {
         return `${vars.scenarioTitle} (${vars.scenarioTags.join(',')} ${vars.featureTags.join(',')})`;
       },

--- a/libs/shared/flagd-core/package.json
+++ b/libs/shared/flagd-core/package.json
@@ -19,7 +19,7 @@
     "object-hash": "^3.0.0",
     "imurmurhash": "^0.1.4",
     "semver": "^7.6.3",
-    "json-logic-engine": "^4.0.2"
+    "json-logic-engine": "5.0.7"
   },
   "devDependencies": {
     "ajv": "^8.12.0"

--- a/libs/shared/flagd-core/src/lib/parser.ts
+++ b/libs/shared/flagd-core/src/lib/parser.ts
@@ -98,7 +98,7 @@ function transform(flagCfg: string): string {
 
   for (const key in evaluators) {
     const replacer = JSON.stringify(evaluators[key]).replaceAll(bracketReplacer, '');
-    const refRegex = new RegExp('"\\$ref":(\\s)*"' + key + '"', 'g');
+    const refRegex = new RegExp('"\\$ref"(\\s)*:(\\s)*"' + key + '"', 'g');
 
     transformed = transformed.replaceAll(refRegex, replacer);
   }

--- a/libs/shared/flagd-core/src/lib/parser.ts
+++ b/libs/shared/flagd-core/src/lib/parser.ts
@@ -20,7 +20,6 @@ type FlagSet = {
 };
 
 const evaluatorKey = '$evaluators';
-const bracketReplacer = new RegExp('^[^{]*\\{|}[^}]*$', 'g');
 
 const errorMessages = 'invalid flagd flag configuration';
 
@@ -94,13 +93,14 @@ function transform(flagCfg: string): string {
     return flagCfg;
   }
 
-  let transformed = flagCfg;
+  // round-trip to normalize whitespace so we can use plain string matching
+  let transformed = JSON.stringify(JSON.parse(flagCfg));
 
   for (const key in evaluators) {
-    const replacer = JSON.stringify(evaluators[key]).replaceAll(bracketReplacer, '');
-    const refRegex = new RegExp('"\\$ref"(\\s)*:(\\s)*"' + key + '"', 'g');
+    const replacer = JSON.stringify(evaluators[key]);
+    const refPattern = '{"$ref":"' + key + '"}';
 
-    transformed = transformed.replaceAll(refRegex, replacer);
+    transformed = transformed.replaceAll(refPattern, replacer);
   }
 
   return transformed;

--- a/libs/shared/flagd-core/src/lib/targeting/sem-ver.ts
+++ b/libs/shared/flagd-core/src/lib/targeting/sem-ver.ts
@@ -1,29 +1,53 @@
-import { compare, parse } from 'semver';
+import { compare, coerce, parse } from 'semver';
+import type { SemVer } from 'semver';
 import { getLoggerFromContext } from './common';
 import type { EvaluationContextWithLogger } from './common';
 
 export const semVerRule = 'sem_ver';
 
-export function semVer(data: unknown, context: EvaluationContextWithLogger): boolean {
+/**
+ * Parse a version string with lenient handling:
+ * - strips v/V prefix
+ * - coerces partial versions (e.g. "1", "1.0")
+ * - converts numeric inputs to strings
+ *
+ * Returns null for truly invalid versions (e.g. "not-a-version", "2.0.0.0").
+ */
+function normalizeVersion(raw: unknown): SemVer | null {
+  const str = String(raw).replace(/^[vV]/, '');
+  const strict = parse(str);
+  if (strict) {
+    return strict;
+  }
+  // coerce partial versions like "1" or "1.2", but reject anything that
+  // doesn't look like a numeric version (coerce is too aggressive otherwise;
+  // e.g. it extracts "1" from "myVersion_1")
+  if (/^\d+(\.\d+)?$/.test(str)) {
+    return coerce(str);
+  }
+  return null;
+}
+
+export function semVer(data: unknown, context: EvaluationContextWithLogger): boolean | null {
   const logger = getLoggerFromContext(context);
   if (!Array.isArray(data)) {
     logger.debug(`Invalid ${semVerRule} configuration: Expected an array`);
-    return false;
+    return null;
   }
 
   const args = Array.from(data);
 
   if (args.length != 3) {
     logger.debug(`Invalid ${semVerRule} configuration: Expected 3 arguments, got ${args.length}`);
-    return false;
+    return null;
   }
 
-  const semVer1 = parse(args[0]);
-  const semVer2 = parse(args[2]);
+  const semVer1 = normalizeVersion(args[0]);
+  const semVer2 = normalizeVersion(args[2]);
 
   if (!semVer1 || !semVer2) {
     logger.debug(`Invalid ${semVerRule} configuration: Unable to parse semver`);
-    return false;
+    return null;
   }
 
   const operator = String(args[1]);
@@ -48,5 +72,6 @@ export function semVer(data: unknown, context: EvaluationContextWithLogger): boo
       return semVer1.major == semVer2.major && semVer1.minor == semVer2.minor;
   }
 
-  return false;
+  logger.debug(`Invalid ${semVerRule} configuration: Unknown operator '${operator}'`);
+  return null;
 }

--- a/libs/shared/flagd-core/src/lib/targeting/string-comp.ts
+++ b/libs/shared/flagd-core/src/lib/targeting/string-comp.ts
@@ -12,21 +12,21 @@ export function endsWith(data: unknown, context: EvaluationContextWithLogger) {
   return compare(endsWithRule, data, context);
 }
 
-function compare(method: string, data: unknown, context: EvaluationContextWithLogger): boolean {
+function compare(method: string, data: unknown, context: EvaluationContextWithLogger): boolean | null {
   const logger = getLoggerFromContext(context);
   if (!Array.isArray(data)) {
     logger.debug('Invalid comparison configuration: input is not an array');
-    return false;
+    return null;
   }
 
   if (data.length != 2) {
     logger.debug(`Invalid comparison configuration: invalid array length ${data.length}`);
-    return false;
+    return null;
   }
 
   if (typeof data[0] !== 'string' || typeof data[1] !== 'string') {
     logger.debug('Invalid comparison configuration: array values are not strings');
-    return false;
+    return null;
   }
 
   switch (method) {
@@ -36,6 +36,6 @@ function compare(method: string, data: unknown, context: EvaluationContextWithLo
       return data[0].endsWith(data[1]);
     default:
       logger.debug(`Invalid comparison configuration: Invalid method '${method}'`);
-      return false;
+      return null;
   }
 }


### PR DESCRIPTION
* support v/V prefix in semver
* support version "metadata" in semver
* fix whitespace handling in $refs
* return null on errors

:warning: wait until flagd/RPC is updated to merge.

Fixes: https://github.com/open-feature/js-sdk-contrib/issues/1515

---

Related:
* https://github.com/open-feature/flagd/pull/1950
* https://github.com/open-feature/java-sdk-contrib/pull/1778
* https://github.com/open-feature/dotnet-sdk-contrib/pull/635
* https://github.com/open-feature/python-sdk-contrib/pull/386
* https://github.com/open-feature/go-sdk-contrib/pull/874