### PR TITLE
feat: add getFlags method to LocalStorageProvider

### DIFF
--- a/libs/providers/localstorage/src/lib/localstorage-provider.spec.ts
+++ b/libs/providers/localstorage/src/lib/localstorage-provider.spec.ts
@@ -1,12 +1,22 @@
 import { ClientProviderEvents, FlagNotFoundError, ParseError } from '@openfeature/web-sdk';
 import { LocalStorageProvider } from './localstorage-provider';
 
+const mockNoLocalStorage = () => {
+  // @ts-expect-error we intentionally want to simulate an environment where localStorage is not defined (e.g., SSR)
+  delete global.localStorage;
+};
+
 describe('LocalStorage Provider', () => {
   const localStorageProvider = new LocalStorageProvider();
+  const originalLocalStorage = global.localStorage;
 
   beforeEach(() => {
     jest.resetModules();
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    global.localStorage = originalLocalStorage;
   });
 
   afterAll(() => {
@@ -38,6 +48,11 @@ describe('LocalStorage Provider', () => {
       localStorage.setItem('openfeature.bool-value', 'invalid');
       expect(() => localStorageProvider.resolveBooleanEvaluation('bool-value')).toThrow(ParseError);
     });
+
+    it('should not find a flag if localStorage is not defined', () => {
+      mockNoLocalStorage();
+      expect(() => localStorageProvider.resolveBooleanEvaluation('bool-value')).toThrow(FlagNotFoundError);
+    });
   });
 
   describe('resolveNumberEvaluation', () => {
@@ -61,6 +76,11 @@ describe('LocalStorage Provider', () => {
       localStorage.setItem('openfeature.num-value', 'invalid');
       expect(() => localStorageProvider.resolveNumberEvaluation('num-value')).toThrow(ParseError);
     });
+
+    it('should not find a flag if localStorage is not defined', () => {
+      mockNoLocalStorage();
+      expect(() => localStorageProvider.resolveNumberEvaluation('num-value')).toThrow(FlagNotFoundError);
+    });
   });
 
   describe('resolveStringEvaluation', () => {
@@ -70,6 +90,11 @@ describe('LocalStorage Provider', () => {
         reason: 'STATIC',
         value: 'openfeature',
       });
+    });
+
+    it('should not find a flag if localStorage is not defined', () => {
+      mockNoLocalStorage();
+      expect(() => localStorageProvider.resolveStringEvaluation('str-value')).toThrow(FlagNotFoundError);
     });
   });
 
@@ -112,6 +137,11 @@ describe('LocalStorage Provider', () => {
         reason: 'STATIC',
         value: ['openfeature'],
       });
+    });
+
+    it('should not find a flag if localStorage is not defined', () => {
+      mockNoLocalStorage();
+      expect(() => localStorageProvider.resolveObjectEvaluation('obj-value')).toThrow(FlagNotFoundError);
     });
   });
 
@@ -187,6 +217,11 @@ describe('LocalStorage Provider', () => {
         flagsChanged: ['bool-value', 'str-value'],
       });
     });
+
+    it('should throw if localStorage is not defined', () => {
+      mockNoLocalStorage();
+      expect(() => localStorageProvider.setFlags({ 'bool-value': true })).toThrow(ReferenceError);
+    });
   });
 
   describe('clearFlags', () => {
@@ -211,6 +246,11 @@ describe('LocalStorage Provider', () => {
         flagsChanged: ['bool-value', 'num-value'],
       });
     });
+
+    it('should throw if localStorage is not defined', () => {
+      mockNoLocalStorage();
+      expect(() => localStorageProvider.clearFlags()).toThrow(ReferenceError);
+    });
   });
 
   describe('getFlags', () => {
@@ -226,6 +266,11 @@ describe('LocalStorage Provider', () => {
 
     it('should return an empty object if no flags match the provider prefix', () => {
       localStorage.setItem('otherprovider.str-value', 'openfeature');
+      expect(localStorageProvider.getFlags()).toEqual({});
+    });
+
+    it('should return an empty object if localStorage is not defined', () => {
+      mockNoLocalStorage();
       expect(localStorageProvider.getFlags()).toEqual({});
     });
   });

--- a/libs/providers/localstorage/src/lib/localstorage-provider.spec.ts
+++ b/libs/providers/localstorage/src/lib/localstorage-provider.spec.ts
@@ -212,4 +212,21 @@ describe('LocalStorage Provider', () => {
       });
     });
   });
+
+  describe('getFlags', () => {
+    it('should return all flags from localStorage that match the provider prefix', () => {
+      localStorage.setItem('openfeature.bool-value', 'true');
+      localStorage.setItem('openfeature.num-value', '1.25');
+      localStorage.setItem('otherprovider.str-value', 'openfeature');
+      expect(localStorageProvider.getFlags()).toEqual({
+        'bool-value': 'true',
+        'num-value': '1.25',
+      });
+    });
+
+    it('should return an empty object if no flags match the provider prefix', () => {
+      localStorage.setItem('otherprovider.str-value', 'openfeature');
+      expect(localStorageProvider.getFlags()).toEqual({});
+    });
+  });
 });

--- a/libs/providers/localstorage/src/lib/localstorage-provider.ts
+++ b/libs/providers/localstorage/src/lib/localstorage-provider.ts
@@ -117,14 +117,7 @@ export class LocalStorageProvider implements Provider {
    * Removes all flags from localStorage that match the provider's prefix.
    */
   clearFlags(): void {
-    const flagKeys: string[] = [];
-
-    for (let i = 0; i < localStorage.length; i++) {
-      const localStorageKey = localStorage.key(i);
-      if (localStorageKey !== null && localStorageKey.startsWith(this.options.prefix ?? '')) {
-        flagKeys.push(localStorageKey.slice(this.options.prefix?.length));
-      }
-    }
+    const flagKeys = this.enumerateLocalStorage();
 
     for (const flagKey of flagKeys) {
       localStorage.removeItem(`${this.options.prefix ?? ''}${flagKey}`);
@@ -134,6 +127,40 @@ export class LocalStorageProvider implements Provider {
       message: 'Flags updated',
       flagsChanged: flagKeys,
     });
+  }
+
+  /**
+   * Lists all flags in localStorage that match the provider's prefix with their raw string values.
+   */
+  getFlags(): Record<string, string> {
+    if (typeof localStorage === 'undefined') {
+      return {};
+    }
+
+    const flagKeys = this.enumerateLocalStorage();
+    const flags: Record<string, string> = {};
+
+    for (const flagKey of flagKeys) {
+      const value = localStorage.getItem(`${this.options.prefix ?? ''}${flagKey}`);
+      if (value !== null) {
+        flags[flagKey] = value;
+      }
+    }
+
+    return flags;
+  }
+
+  private enumerateLocalStorage(): string[] {
+    const flagKeys: string[] = [];
+
+    for (let i = 0; i < localStorage.length; i++) {
+      const localStorageKey = localStorage.key(i);
+      if (localStorageKey !== null && localStorageKey.startsWith(this.options.prefix ?? '')) {
+        flagKeys.push(localStorageKey.slice(this.options.prefix?.length));
+      }
+    }
+
+    return flagKeys;
   }
 
   private evaluateLocalStorage<T extends JsonValue>(


### PR DESCRIPTION
## This PR

While implementing https://github.com/grafana/grafana/pull/123451, I realised it'd be rather useful if the provider had a self-contained way to access all the flags it could evaluate, rather than needing to interface with localStorage manually. This intentionally returns just the raw string values from localStorage, as there is ambiguity in how they would be parsed, depending on which resolve method is used.