### PR TITLE
fix: wasm memory copying in wrapper

### DIFF
--- a/libs/providers/go-feature-flag/src/lib/wasm/evaluate-wasm.ts
+++ b/libs/providers/go-feature-flag/src/lib/wasm/evaluate-wasm.ts
@@ -17,6 +17,7 @@ export class EvaluateWasm {
   private readonly go: Go;
   private readonly logger?: Logger;
   private readonly wasmBinaryPath?: string;
+  private readonly encoder: TextEncoder;
 
   /**
    * Constructor of the EvaluationWasm. It initializes the WASM module and the host functions.
@@ -27,6 +28,7 @@ export class EvaluateWasm {
     this.logger = logger;
     this.wasmBinaryPath = wasmBinaryPath;
     this.go = new Go();
+    this.encoder = new TextEncoder();
   }
 
   /**
@@ -226,7 +228,7 @@ export class EvaluateWasm {
       }
 
       // Serialize the input to JSON
-      const wasmInputSerialized = new TextEncoder().encode(JSON.stringify(wasmInput));
+      const wasmInputSerialized = this.encoder.encode(JSON.stringify(wasmInput));
 
       // Copy input to WASM memory
       const inputPtr = this.copyToMemory(wasmInputSerialized);
@@ -322,6 +324,8 @@ export class EvaluateWasm {
     const ptr = mallocFunction(inputBytes.length + 1);
     if (typeof ptr !== 'number') {
       throw new WasmInvalidResultException('Malloc should return a number value.');
+    } else if (ptr === 0) {
+      throw new WasmInvalidResultException('Failed to allocate memory in WASM module.');
     }
 
     // Write the string to WASM memory

--- a/libs/providers/go-feature-flag/src/lib/wasm/evaluate-wasm.ts
+++ b/libs/providers/go-feature-flag/src/lib/wasm/evaluate-wasm.ts
@@ -226,14 +226,14 @@ export class EvaluateWasm {
       }
 
       // Serialize the input to JSON
-      const wasmInputAsStr = JSON.stringify(wasmInput);
+      const wasmInputSerialized = new TextEncoder().encode(JSON.stringify(wasmInput));
 
       // Copy input to WASM memory
-      const inputPtr = this.copyToMemory(wasmInputAsStr);
+      const inputPtr = this.copyToMemory(wasmInputSerialized);
 
       try {
         // Call the WASM evaluate function
-        const evaluateRes = this.callWasmEvaluate(inputPtr, wasmInputAsStr.length);
+        const evaluateRes = this.callWasmEvaluate(inputPtr, wasmInputSerialized.length);
 
         // Read the result from WASM memory
         const resAsString = this.readFromMemory(evaluateRes);
@@ -308,7 +308,7 @@ export class EvaluateWasm {
    * @returns the address location of this string
    * @throws WasmInvalidResultException - If for any reasons we have an issue calling the wasm module.
    */
-  private copyToMemory(inputString: string): number {
+  private copyToMemory(inputBytes: Uint8Array): number {
     if (!this.wasmExports) {
       throw new WasmFunctionNotFoundException('malloc');
     }
@@ -319,13 +319,13 @@ export class EvaluateWasm {
       throw new WasmFunctionNotFoundException('malloc');
     }
 
-    const ptr = mallocFunction(inputString.length + 1);
+    const ptr = mallocFunction(inputBytes.length + 1);
     if (typeof ptr !== 'number') {
       throw new WasmInvalidResultException('Malloc should return a number value.');
     }
 
     // Write the string to WASM memory
-    this.writeStringToMemory(ptr, inputString);
+    this.writeStringToMemory(ptr, inputBytes);
     return ptr;
   }
 
@@ -334,14 +334,12 @@ export class EvaluateWasm {
    * @param ptr - Pointer to write to
    * @param str - String to write
    */
-  private writeStringToMemory(ptr: number, str: string): void {
+  private writeStringToMemory(ptr: number, bytes: Uint8Array): void {
     if (!this.wasmMemory) {
       throw new WasmInvalidResultException('WASM memory not available.');
     }
 
     const buffer = new Uint8Array(this.wasmMemory.buffer);
-    const encoder = new TextEncoder();
-    const bytes = encoder.encode(str);
 
     for (let i = 0; i < bytes.length; i++) {
       buffer[ptr + i] = bytes[i];


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes a memory-copying issue in the WASM wrapper. Wrapper used to take `inputStr.length` for byte buffer to encode the `inputStr`. 
The problem is when inputStr contains characters that are UTF-8 but encoded in two or more bytes. This results in trying to write to non-allocated memory space, resulting in invalid memory access.

This PR fixes this by first encoding the string and using byte array lenghts for allocation.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

