### PR TITLE
fix(ofrep-web): fall back to FNV-1a hash when crypto.subtle is unavailable

### DIFF
--- a/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
@@ -103,4 +103,39 @@ describe('Storage (persistent flag cache)', () => {
     expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
     expect(await storageA.getStorageKey(tk)).not.toBe(await storageNoPrefix.getStorageKey(tk));
   });
+
+  describe('when crypto.subtle is unavailable (non-secure context)', () => {
+    let subtleSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      subtleSpy = jest.spyOn(crypto, 'subtle', 'get').mockReturnValue(undefined as never);
+    });
+
+    afterEach(() => {
+      subtleSpy.mockRestore();
+    });
+
+    it('produces a valid versioned storage key without the raw targeting key', async () => {
+      const storage = new Storage('local-cache-first');
+      const tk = 'user-pii-21640825-95e7-4335-b149-bd6881cf7875';
+      const key = await storage.getStorageKey(tk);
+      expect(key.startsWith('ofrep-web-provider:v1:')).toBe(true);
+      expect(key).not.toContain(tk);
+      expect(key.split(':')[2]).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('maps different targeting keys to different storage keys', async () => {
+      const storage = new Storage('local-cache-first');
+      expect(await storage.getStorageKey('a')).not.toBe(await storage.getStorageKey('b'));
+    });
+
+    it('stores and retrieves flags without throwing', async () => {
+      const storage = new Storage('local-cache-first');
+      await storage.store('user-1', boolFlagCache, '"etag"');
+      const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+      expect(result).not.toBeUndefined();
+      expect(result!.flags).toEqual(boolFlagCache);
+      expect(result!.etag).toBe('"etag"');
+    });
+  });
 });

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -12,7 +12,7 @@ const STORAGE_NS = 'ofrep-web-provider';
 export interface PersistedEntry {
   /** Schema version — used to discard entries written by older provider versions. */
   version: number;
-  /** SHA-256 hex digest (truncated to 16 chars) of `targetingKey` (or `cacheKeyPrefix + ":" + targetingKey` when configured). */
+  /** Hex digest (16 chars) of `targetingKey` (or `cacheKeyPrefix + ":" + targetingKey` when configured). SHA-256 when crypto.subtle is available, FNV-1a fallback otherwise. */
   cacheKeyHash: string;
   /** ETag returned by the server for this evaluation, used for efficient revalidation. */
   etag: string | null;
@@ -40,18 +40,40 @@ export class Storage {
   }
 
   /**
-   * Computes a SHA-256 hash (truncated to 16 hex chars) of the targeting key,
-   * including the cacheKeyPrefix when set.
+   * Hashes the targeting key (with optional prefix) to a 16-char hex string.
+   * Uses SHA-256 via crypto.subtle when available (secure contexts).
+   * Falls back to a double-pass FNV-1a-32 in non-secure contexts where crypto.subtle is absent.
    */
   private async _hashInput(targetingKey: string): Promise<string> {
     const input = this._cacheKeyPrefix ? `${this._cacheKeyPrefix}:${targetingKey}` : targetingKey;
-    const encoded = new TextEncoder().encode(input);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('')
-      .slice(0, 16);
+    if (typeof crypto !== 'undefined' && crypto.subtle) {
+      const encoded = new TextEncoder().encode(input);
+      const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      return hashArray
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')
+        .slice(0, 16);
+    }
+    return this._fnvHash(input);
+  }
+
+  /**
+   * Double-pass FNV-1a-32 producing a 16-char hex string.
+   * Used as a fallback when crypto.subtle is unavailable (non-secure contexts).
+   */
+  private _fnvHash(input: string): string {
+    const fnv1a32 = (str: string, offset: number): number => {
+      let h = offset >>> 0;
+      for (let i = 0; i < str.length; i++) {
+        h ^= str.charCodeAt(i);
+        h = Math.imul(h, 0x01000193) >>> 0;
+      }
+      return h;
+    };
+    const lo = fnv1a32(input, 0x811c9dc5);
+    const hi = fnv1a32(input, 0x27d4eb2f);
+    return lo.toString(16).padStart(8, '0') + hi.toString(16).padStart(8, '0');
   }
 
   /**


### PR DESCRIPTION
## Summary

- `Storage._hashInput` used `crypto.subtle.digest` unconditionally, which throws in non-secure contexts (HTTP on non-localhost IPs, some older browsers)
- The error propagated through `_fetchFlags` and caused `initialize` to fail in those environments
- Added a `_fnvHash` fallback (double-pass FNV-1a-32, 16 hex chars) used when `crypto.subtle` is not available; SHA-256 behavior is unchanged in secure contexts
- Added tests covering the non-secure-context path

### Notes

An alternative approach would be to use `btoa(input)` as the fallback instead of FNV — it's universally available including non-secure contexts and requires no custom logic. The trade-off is that `btoa` is just base64 encoding, so the targeting key is directly recoverable from the localStorage key name (breaking the privacy property the hash provides). FNV-1a preserves that property without requiring the Crypto API, which is why it was chosen here.

### Related Issues

Addresses review feedback in #1535