### PR TITLE
fix: require ofrep-core ^2.2.0

### DIFF
--- a/libs/providers/ofrep-web/package.json
+++ b/libs/providers/ofrep-web/package.json
@@ -17,6 +17,6 @@
     "@openfeature/web-sdk": "^1.4.0"
   },
   "dependencies": {
-    "@openfeature/ofrep-core": "^2.1.0"
+    "@openfeature/ofrep-core": "^2.2.0"
   }
 }

--- a/libs/providers/ofrep/package.json
+++ b/libs/providers/ofrep/package.json
@@ -17,6 +17,6 @@
     "@openfeature/server-sdk": "^1.6.0"
   },
   "dependencies": {
-    "@openfeature/ofrep-core": "^2.1.0"
+    "@openfeature/ofrep-core": "^2.2.0"
   }
 }


### PR DESCRIPTION
Bumps the min ofrep-core dep so `OFREPApiError` resolves.

Closes #1554