### PR TITLE
feat!: DISABLED is a successful evaluation (still defaults)

### DIFF
--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -302,9 +302,13 @@ export class GRPCService implements Service {
       .then((resolved) => resolved, this.onRejected);
 
     let value = response.value as T;
-    // When no default variant is configured, the server returns an empty/zero proto
-    // value with reason=DEFAULT. In that case, return the caller's code default value.
-    if (response.reason === StandardResolutionReasons.DEFAULT && !response.variant) {
+    // When no variant is configured, the server returns an empty/zero proto value.
+    // This happens for reason=DEFAULT (no defaultVariant) and reason=DISABLED.
+    // In either case, return the caller's code default value.
+    if (
+      !response.variant &&
+      (response.reason === StandardResolutionReasons.DEFAULT || response.reason === StandardResolutionReasons.DISABLED)
+    ) {
       value = defaultValue;
     }
 

--- a/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.spec.ts
@@ -248,12 +248,12 @@ describe('flagd-core validations', () => {
     expect(evaluation.variant).toBeUndefined();
   });
 
-  it('should return reason "error" because the flag is disabled', () => {
+  it('should return reason "disabled" with caller default value when the flag is disabled', () => {
     const flagKey = 'disabledFlag';
     const evaluation = core.resolveBooleanEvaluation(flagKey, false, {});
-    expect(evaluation.reason).toBe(StandardResolutionReasons.ERROR);
-    expect(evaluation.errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
-    expect(evaluation.errorMessage).toBe(`flag '${flagKey}' is disabled`);
+    expect(evaluation.reason).toBe(StandardResolutionReasons.DISABLED);
+    expect(evaluation.errorCode).toBeUndefined();
+    expect(evaluation.errorMessage).toBeUndefined();
     expect(evaluation.value).toBe(false);
     expect(evaluation.variant).toBeUndefined();
   });
@@ -409,11 +409,12 @@ describe('flagd-core error conditions', () => {
     expect(resolved.flagMetadata).toEqual({ version: '1', flagSetId: 'dev' });
   });
 
-  it('should treat disabled flags as not found', () => {
+  it('should resolve disabled flags with reason DISABLED and caller default', () => {
     const resolved = core.resolveBooleanEvaluation('disabledFlag', false, {});
-    expect(resolved.reason).toBe(StandardResolutionReasons.ERROR);
-    expect(resolved.errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
-    expect(resolved.errorMessage).toBeTruthy();
+    expect(resolved.reason).toBe(StandardResolutionReasons.DISABLED);
+    expect(resolved.errorCode).toBeUndefined();
+    expect(resolved.errorMessage).toBeUndefined();
+    expect(resolved.value).toBe(false);
     expect(resolved.flagMetadata).toEqual({ version: '1', flagSetId: 'dev' });
   });
 

--- a/libs/shared/flagd-core/src/lib/flagd-core.ts
+++ b/libs/shared/flagd-core/src/lib/flagd-core.ts
@@ -176,9 +176,7 @@ export class FlagdCore implements Storage {
     if (flag.state === 'DISABLED') {
       return {
         value: defaultValue,
-        reason: StandardResolutionReasons.ERROR,
-        errorCode: ErrorCode.FLAG_NOT_FOUND,
-        errorMessage: `flag '${flagKey}' is disabled`,
+        reason: StandardResolutionReasons.DISABLED,
         flagMetadata: flag.metadata,
       };
     }


### PR DESCRIPTION
- Disabled flags now resolve successfully with `reason=DISABLED` instead of `errorCode=FLAG_NOT_FOUND`. See the [ADR](https://github.com/open-feature/flagd/blob/main/docs/architecture-decisions/disabled-flag-evaluation.md).
- Breaking, but barely: resolved values are unchanged (the caller-provided default is still surfaced).
- The break is only observable for consumers that inspect `reason` / `errorCode` on disabled-flag evaluations.

Closes #1552
Part of open-feature/flagd#1965
