### PR TITLE
fix: SSE eventstream urls are not stored in cache

### DIFF
--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
@@ -392,10 +392,7 @@ describe('OFREPWebProvider', () => {
         ),
       );
       const providerName = expect.getState().currentTestName || 'test-provider';
-      const provider = new OFREPWebProvider(
-        { baseUrl: endpointBaseURL, cacheMode: 'network-first' },
-        new TestLogger(),
-      );
+      const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, cacheMode: 'network-first' }, new TestLogger());
       await OpenFeature.setContext(defaultContext);
       await OpenFeature.setProviderAndWait(providerName, provider);
 
@@ -441,15 +438,48 @@ describe('OFREPWebProvider', () => {
       expect((provider as any)._sseManager).not.toBeUndefined();
       expect(MockES).toHaveBeenCalledWith('https://sse.example.com/stream');
     });
+
+    it('connects SSE from the persisted streams when the cache-first refresh returns 304', async () => {
+      // Seed the cache with an etag and the persisted event streams. This mirrors a warm
+      // start where the flags are unchanged: the background refresh sends If-None-Match
+      // and the server responds 304 (no body, no eventStreams), so SSE must be established
+      // from the persisted configuration rather than from a 200 response.
+      const storage = new Storage('local-cache-first');
+      const key = await storage.getStorageKey(defaultContext.targetingKey);
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          version: 1,
+          cacheKeyHash: key,
+          etag: '"cached-etag"',
+          writtenAt: new Date().toISOString(),
+          data: {},
+          eventStreams: [{ type: 'sse', url: 'https://sse.example.com/stream' }],
+        }),
+      );
+
+      server.use(
+        http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () => new HttpResponse(null, { status: 304 })),
+      );
+
+      const providerName = expect.getState().currentTestName || 'test-provider';
+      const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL }, new TestLogger());
+      await OpenFeature.setContext(defaultContext);
+      OpenFeature.setProvider(providerName, provider);
+
+      // Wait for both the ready event and the background refresh (304) to complete.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((provider as any)._sseManager).not.toBeUndefined();
+      expect(MockES).toHaveBeenCalledWith('https://sse.example.com/stream');
+    });
   });
 
   describe('changeDetection', () => {
     it('should not start polling or SSE when changeDetection is none', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
-      const provider = new OFREPWebProvider(
-        { baseUrl: endpointBaseURL, changeDetection: 'none' },
-        new TestLogger(),
-      );
+      const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, changeDetection: 'none' }, new TestLogger());
       await OpenFeature.setContext({ ...defaultContext, changeConfig: true });
       await OpenFeature.setProviderAndWait(providerName, provider);
       const client = OpenFeature.getClient(providerName);
@@ -633,10 +663,7 @@ describe('OFREPWebProvider', () => {
 
     it('does not schedule backoff when changeDetection is none', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
-      const provider = new OFREPWebProvider(
-        { baseUrl: endpointBaseURL, changeDetection: 'none' },
-        new TestLogger(),
-      );
+      const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, changeDetection: 'none' }, new TestLogger());
       await OpenFeature.setContext(defaultContext);
       await OpenFeature.setProviderAndWait(providerName, provider);
 
@@ -766,9 +793,7 @@ describe('OFREPWebProvider', () => {
       client.addHandler(ClientProviderEvents.Stale, staleHandler);
 
       server.use(
-        http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () =>
-          HttpResponse.json({}, { status: 401 }),
-        ),
+        http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () => HttpResponse.json({}, { status: 401 })),
       );
 
       const handler = mockDocument.addEventListener.mock.calls[0][1];

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -4,12 +4,13 @@ import type {
   EvaluationResponse,
   EventStream,
 } from '@openfeature/ofrep-core';
-import { ErrorMessageMap, OFREPApiError } from '@openfeature/ofrep-core';
 import {
+  ErrorMessageMap,
   type EvaluationFlagValue,
   handleEvaluationError,
   isEvaluationFailureResponse,
   OFREPApi,
+  OFREPApiError,
   OFREPApiFetchError,
   OFREPApiTooManyRequestsError,
   OFREPApiUnauthorizedError,
@@ -271,9 +272,8 @@ export class OFREPWebProvider implements Provider {
       if (cached.metadata) {
         this._flagSetMetadataCache = cached.metadata as MetadataCache;
       }
-      if (cached.eventStreams) {
-        this._eventStreams = cached.eventStreams;
-      }
+      this._eventStreams = cached.eventStreams;
+
       // Serving from cache after a transient network failure. Surface the persisted
       // event streams so the caller can establish SSE without waiting for a 200 — a
       // subsequent successful request may be a 304 that carries no eventStreams.
@@ -625,9 +625,8 @@ export class OFREPWebProvider implements Provider {
       if (cached.metadata) {
         this._flagSetMetadataCache = cached.metadata as MetadataCache;
       }
-      if (cached.eventStreams) {
-        this._eventStreams = cached.eventStreams;
-      }
+      this._eventStreams = cached.eventStreams;
+
       // Connect SSE from the persisted streams: the background refresh below sends
       // If-None-Match and will receive a 304 (no body, no eventStreams) when flags are
       // unchanged, so we must rely on the cached configuration to establish SSE here.

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -1,4 +1,9 @@
-import type { BulkEvaluationRefetchMetadata, EvaluationRequest, EvaluationResponse } from '@openfeature/ofrep-core';
+import type {
+  BulkEvaluationRefetchMetadata,
+  EvaluationRequest,
+  EvaluationResponse,
+  EventStream,
+} from '@openfeature/ofrep-core';
 import { ErrorMessageMap, OFREPApiError } from '@openfeature/ofrep-core';
 import {
   type EvaluationFlagValue,
@@ -69,6 +74,7 @@ export class OFREPWebProvider implements Provider {
   private _sseManager?: SseManager;
   private _sseRetryCount = 0;
   private _sseRetryTimerId?: ReturnType<typeof setTimeout>;
+  private _eventStreams?: EventStream[];
 
   constructor(options: OFREPWebProviderOptions, logger?: Logger) {
     this._options = options;
@@ -265,8 +271,15 @@ export class OFREPWebProvider implements Provider {
       if (cached.metadata) {
         this._flagSetMetadataCache = cached.metadata as MetadataCache;
       }
-      // Serving from cache; SSE/polling will re-establish on the next successful network request.
-      return undefined;
+      if (cached.eventStreams) {
+        this._eventStreams = cached.eventStreams;
+      }
+      // Serving from cache after a transient network failure. Surface the persisted
+      // event streams so the caller can establish SSE without waiting for a 200 — a
+      // subsequent successful request may be a 304 that carries no eventStreams.
+      return this._eventStreams?.length
+        ? { status: BulkEvaluationStatus.SUCCESS_NO_CHANGES, flags: [], eventStreams: this._eventStreams }
+        : undefined;
     }
   }
 
@@ -296,7 +309,9 @@ export class OFREPWebProvider implements Provider {
       const etag = unconditional ? null : this._etag;
       const response = await this._ofrepAPI.postBulkEvaluateFlags(evalReq, etag, sseMetadata);
       if (response.httpStatus === 304) {
-        return { status: BulkEvaluationStatus.SUCCESS_NO_CHANGES, flags: [] };
+        // A 304 has no body, so the server does not (re)send eventStreams. Surface the
+        // last-known streams so SSE can still be (re)connected when flags are unchanged.
+        return { status: BulkEvaluationStatus.SUCCESS_NO_CHANGES, flags: [], eventStreams: this._eventStreams };
       }
 
       if (response.httpStatus !== 200) {
@@ -321,11 +336,18 @@ export class OFREPWebProvider implements Provider {
 
       const listUpdatedFlags = this._getListUpdatedFlags(this._flagCache, newCache);
       this._flagCache = newCache;
+      this._eventStreams = bulkSuccessResp.eventStreams;
       const newEtag = response.httpResponse?.headers.get('etag') ?? null;
       this._flagSetMetadataCache = toFlagMetadata(
         typeof bulkSuccessResp.metadata === 'object' ? bulkSuccessResp.metadata : {},
       );
-      await this._storage.store(context?.targetingKey ?? '', newCache, newEtag, this._flagSetMetadataCache);
+      await this._storage.store(
+        context?.targetingKey ?? '',
+        newCache,
+        newEtag,
+        this._flagSetMetadataCache,
+        this._eventStreams,
+      );
       this._etag = newEtag;
       this._isUsingCache = false;
       return {
@@ -434,7 +456,9 @@ export class OFREPWebProvider implements Provider {
       }
     } catch (error) {
       if (emitStaleOnError) {
-        this.events?.emit(ClientProviderEvents.Stale, { message: `Error while refreshing flags (${reason}): ${error}` });
+        this.events?.emit(ClientProviderEvents.Stale, {
+          message: `Error while refreshing flags (${reason}): ${error}`,
+        });
       } else {
         this._logger?.warn(`Error while refreshing flags (${reason}): ${error}`);
       }
@@ -452,6 +476,10 @@ export class OFREPWebProvider implements Provider {
     const changeDetection = this._options.changeDetection ?? 'sse';
 
     if (result.eventStreams && result.eventStreams.length > 0 && changeDetection === 'sse') {
+      if (!this._sseManager && typeof EventSource === 'undefined') {
+        this._logger?.debug('EventSource is unavailable; skipping SSE connection');
+        return;
+      }
       this.stopPolling();
       this._clearSseRetry();
       if (!this._sseManager) {
@@ -596,6 +624,19 @@ export class OFREPWebProvider implements Provider {
       this._etag = cached.etag;
       if (cached.metadata) {
         this._flagSetMetadataCache = cached.metadata as MetadataCache;
+      }
+      if (cached.eventStreams) {
+        this._eventStreams = cached.eventStreams;
+      }
+      // Connect SSE from the persisted streams: the background refresh below sends
+      // If-None-Match and will receive a 304 (no body, no eventStreams) when flags are
+      // unchanged, so we must rely on the cached configuration to establish SSE here.
+      if (this._eventStreams?.length) {
+        this._connectSseIfAvailable({
+          status: BulkEvaluationStatus.SUCCESS_NO_CHANGES,
+          flags: [],
+          eventStreams: this._eventStreams,
+        });
       }
       void this._refreshFlagsInBackground();
       return true;

--- a/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
@@ -59,6 +59,21 @@ describe('Storage (persistent flag cache)', () => {
     expect(result!.etag).toBe(etag);
   });
 
+  it('stores and retrieves the SSE event streams in the persisted envelope', async () => {
+    const storage = new Storage('local-cache-first');
+    const eventStreams = [{ type: 'sse' as const, url: 'https://sse.example.com/stream' }];
+    await storage.store('user-1', boolFlagCache, '"etag"', undefined, eventStreams);
+    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    expect(result!.eventStreams).toEqual(eventStreams);
+  });
+
+  it('omits event streams from the envelope when none are provided', async () => {
+    const storage = new Storage('local-cache-first');
+    await storage.store('user-1', boolFlagCache, '"etag"');
+    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    expect(result!.eventStreams).toBeUndefined();
+  });
+
   it('stores null ETag when none is provided', async () => {
     const storage = new Storage('local-cache-first');
     await storage.store('user-1', boolFlagCache, null);

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -1,3 +1,4 @@
+import type { EventStream } from '@openfeature/ofrep-core';
 import type { Logger } from '@openfeature/web-sdk';
 import type { FlagCache } from '../model/in-memory-cache';
 import type { CacheMode } from '../model/ofrep-web-provider-options';
@@ -22,6 +23,8 @@ export interface PersistedEntry {
   data: FlagCache;
   /** Persisted flag-set metadata returned by the bulk evaluation response. */
   metadata?: Record<string, unknown>;
+  /** SSE event streams returned by the bulk evaluation response (ADR-0008). Only sent on a 200, so persisting them lets SSE reconnect after a cache load or 304. */
+  eventStreams?: EventStream[];
 }
 
 export class Storage {
@@ -94,6 +97,7 @@ export class Storage {
     flags: FlagCache,
     etag: string | null,
     metadata?: Record<string, unknown>,
+    eventStreams?: EventStream[],
   ): Promise<void> {
     if (this._disabled) return;
     const key = await this.getStorageKey(targetingKey);
@@ -104,6 +108,7 @@ export class Storage {
       writtenAt: new Date().toISOString(),
       data: flags,
       ...(metadata !== undefined && { metadata }),
+      ...(eventStreams !== undefined && { eventStreams }),
     };
     try {
       localStorage.setItem(key, JSON.stringify(entry));
@@ -123,7 +128,10 @@ export class Storage {
   async retrieve(
     targetingKey: string,
     ttlSeconds: number,
-  ): Promise<{ flags: FlagCache; etag: string | null; metadata?: Record<string, unknown> } | undefined> {
+  ): Promise<
+    | { flags: FlagCache; etag: string | null; metadata?: Record<string, unknown>; eventStreams?: EventStream[] }
+    | undefined
+  > {
     if (this._disabled) return undefined;
     try {
       const raw = localStorage.getItem(await this.getStorageKey(targetingKey));
@@ -141,7 +149,7 @@ export class Storage {
         return undefined;
       }
 
-      return { flags: entry.data, etag: entry.etag, metadata: entry.metadata };
+      return { flags: entry.data, etag: entry.etag, metadata: entry.metadata, eventStreams: entry.eventStreams };
     } catch (error) {
       this._logger?.error(`Error retrieving flag cache from local storage: ${error}`);
       return undefined;


### PR DESCRIPTION

## This PR

A warm load will fail to connect to SSE - raised here: https://cloud-native.slack.com/archives/C06E4DE6S07/p1780406659255959

SSE eventstreams are not tracked as part of the cache, so a valid 304 returned from the flags endpoint will result in never connecting to SSE until that endpoint returns a 200.

