### PR TITLE
feat(flagsmith-client)!: Switch to `@flagsmith/flagsmith`

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -12,7 +12,7 @@
   "libs/providers/ofrep": "0.2.5",
   "libs/providers/ofrep-web": "0.4.1",
   "libs/providers/flipt": "0.1.4",
-  "libs/providers/flagsmith-client": "0.2.0",
+  "libs/providers/flagsmith-client": "1.0.0",
   "libs/providers/flipt-web": "0.1.6",
   "libs/providers/multi-provider": "0.1.3",
   "libs/providers/multi-provider-web": "0.0.4",

--- a/libs/providers/flagsmith-client/package-lock.json
+++ b/libs/providers/flagsmith-client/package-lock.json
@@ -1,17 +1,24 @@
 {
   "name": "@openfeature/flagsmith-client-provider",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openfeature/flagsmith-client-provider",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@openfeature/web-sdk": "^1.0.0",
-        "flagsmith": "^9.3.1"
+        "@flagsmith/flagsmith": ">=12.0.1",
+        "@openfeature/web-sdk": "^1.0.0"
       }
+    },
+    "node_modules/@flagsmith/flagsmith": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-12.0.1.tgz",
+      "integrity": "sha512-umrkh+zBUU5slA7nWnx4ktRuv2IomjD0iMzkB28pWJKv312VfENLTAABhrN9DHk/ZgAM2RzqQ5mbSHjQusQ2IA==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@openfeature/core": {
       "version": "1.0.0",
@@ -27,13 +34,6 @@
       "peerDependencies": {
         "@openfeature/core": "1.0.0"
       }
-    },
-    "node_modules/flagsmith": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/flagsmith/-/flagsmith-9.3.1.tgz",
-      "integrity": "sha512-yCywwo8vGU3QTHyBA1esBakKs4qwNwbq/9frG2V88NvZnOLP08WYOI+XWd4QDavuKF3mapr+jlYLCscXf+ka4Q==",
-      "license": "BSD-3-Clause",
-      "peer": true
     }
   }
 }

--- a/libs/providers/flagsmith-client/package.json
+++ b/libs/providers/flagsmith-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfeature/flagsmith-client-provider",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/open-feature/js-sdk-contrib.git",
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@openfeature/web-sdk": "^1.0.0",
-    "flagsmith": "^9.3.1"
+    "@flagsmith/flagsmith": ">=12.0.1"
   },
   "dependencies": {}
 }

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
@@ -14,7 +14,7 @@ import {
   CACHE_KEY,
 } from './flagsmith.mocks';
 import { OpenFeature, ProviderEvents } from '@openfeature/web-sdk';
-import { createFlagsmithInstance } from 'flagsmith';
+import { createFlagsmithInstance } from '@flagsmith/flagsmith';
 
 const logger = {
   error: jest.fn(),

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
@@ -9,8 +9,8 @@ import type {
   ResolutionReason,
 } from '@openfeature/web-sdk';
 import { OpenFeatureEventEmitter, ProviderEvents, TypeMismatchError } from '@openfeature/web-sdk';
-import { createFlagsmithInstance } from 'flagsmith';
-import type { ClientEvaluationContext, IFlagsmith, IInitConfig, IState, ITraits } from 'flagsmith/types';
+import { createFlagsmithInstance } from '@flagsmith/flagsmith';
+import type { ClientEvaluationContext, IFlagsmith, IInitConfig, IState, ITraits } from '@flagsmith/flagsmith/types';
 import type { FlagType } from './type-factory';
 import { typeFactory } from './type-factory';
 

--- a/libs/providers/flagsmith-client/src/lib/flagsmith.mocks.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith.mocks.ts
@@ -1,4 +1,4 @@
-import type { IFlagsmithResponse, IInitConfig } from 'flagsmith/types';
+import type { IFlagsmithResponse, IInitConfig } from '@flagsmith/flagsmith/types';
 type Flatten<T> = T extends unknown[] ? T[number] : T;
 type FeatureResponse = Flatten<IFlagsmithResponse['flags']>;
 type Callback = (err: Error | null, val: string | null) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@configcat/sdk": "^1.0.1",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-web": "^1.4.0",
+        "@flagsmith/flagsmith": "^12.0.1",
         "@flipt-io/flipt": "^1.2.0",
         "@flipt-io/flipt-client-js": "^0.2.0",
         "@growthbook/growthbook": "^1.3.1",
@@ -28,7 +29,6 @@
         "ajv": "^8.18.0",
         "axios": "1.16.0",
         "copy-anything": "^3.0.5",
-        "flagsmith": "^9.3.1",
         "flagsmith-nodejs": "^6.1.0",
         "imurmurhash": "^0.1.4",
         "json-logic-engine": "4.0.6",
@@ -3223,6 +3223,12 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@flagsmith/flagsmith": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-12.0.1.tgz",
+      "integrity": "sha512-umrkh+zBUU5slA7nWnx4ktRuv2IomjD0iMzkB28pWJKv312VfENLTAABhrN9DHk/ZgAM2RzqQ5mbSHjQusQ2IA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@flipt-io/flipt": {
       "version": "1.2.0",
@@ -14656,12 +14662,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/flagsmith": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/flagsmith/-/flagsmith-9.3.2.tgz",
-      "integrity": "sha512-dpU1U8fjLBf6uzuJuOHRGS2forpiHING0amCFtF9ych+Yeth4cYMy3ZT0cx0lhE7S4o2v9itU0fge+toP3Td6A==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/flagsmith-nodejs": {
       "version": "6.1.0",
@@ -27677,6 +27677,11 @@
       "version": "8.57.1",
       "dev": true
     },
+    "@flagsmith/flagsmith": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@flagsmith/flagsmith/-/flagsmith-12.0.1.tgz",
+      "integrity": "sha512-umrkh+zBUU5slA7nWnx4ktRuv2IomjD0iMzkB28pWJKv312VfENLTAABhrN9DHk/ZgAM2RzqQ5mbSHjQusQ2IA=="
+    },
     "@flipt-io/flipt": {
       "version": "1.2.0"
     },
@@ -35072,11 +35077,6 @@
       "requires": {
         "semver-regex": "^4.0.5"
       }
-    },
-    "flagsmith": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/flagsmith/-/flagsmith-9.3.2.tgz",
-      "integrity": "sha512-dpU1U8fjLBf6uzuJuOHRGS2forpiHING0amCFtF9ych+Yeth4cYMy3ZT0cx0lhE7S4o2v9itU0fge+toP3Td6A=="
     },
     "flagsmith-nodejs": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ajv": "^8.18.0",
     "axios": "1.16.0",
     "copy-anything": "^3.0.5",
-    "flagsmith": "^9.3.1",
+    "@flagsmith/flagsmith": "^12.0.1",
     "flagsmith-nodejs": "^6.1.0",
     "imurmurhash": "^0.1.4",
     "json-logic-engine": "4.0.6",


### PR DESCRIPTION
BREAKING CHANGE: @openfeature/flagsmith-client-provider now requires `@flagsmith/flagsmith` >=12.0.1 instead of the deprecated `flagsmith` package.

## This PR

- updates `@openfeature/flagsmith-client-provider` to use `@flagsmith/flagsmith`
- bumps `@openfeature/flagsmith-client-provider` to `1.0.0`
- updates tests and lockfiles for the scoped Flagsmith package

### Related Issues

None

### Notes

Consumers must replace `flagsmith` ([which is deprecated](https://www.npmjs.com/package/flagsmith)) with `@flagsmith/flagsmith >=12.0.1`. 

### Follow-up Tasks

### How to test