### PR TITLE
fix(ofrep-web-provider): use base URL + eval context for cache key

### DIFF
--- a/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
+++ b/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
@@ -1,3 +1,4 @@
+import type { EvaluationContext } from '@openfeature/web-sdk';
 import type { OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
 
 export type CacheMode = 'local-cache-first' | 'network-first' | 'disabled';
@@ -72,4 +73,12 @@ export type OFREPWebProviderOptions = OFREPProviderBaseOptions & {
    * A sensible value is a project key or any other string that uniquely identifies this provider.
    */
   cacheKeyPrefix?: string;
+
+  /**
+   * cacheKeyTransformer is used in the cache key hash to allow for controlling which parts of the
+   * evaluation context are included in the cache key. By default, the whole context is used.
+   *
+   * This can be used to omit known volatile context fields from the cache key.
+   */
+  cacheKeyTransformer?: (context: EvaluationContext | undefined) => EvaluationContext | undefined;
 };

--- a/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
+++ b/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
@@ -67,10 +67,9 @@ export type OFREPWebProviderOptions = OFREPProviderBaseOptions & {
   /**
    * cacheKeyPrefix is included in the cache key hash to prevent collisions when multiple
    * OFREP provider instances share the same storage partition (e.g. the same browser origin).
-   * When set, the cache key becomes `hash(cacheKeyPrefix + ":" + targetingKey)`.
+   * When set, the cache key is `hash(cacheKeyPrefix + ":" + baseUrl + ":" + context)`.
    *
-   * A sensible value is the OFREP base URL, a project key, or any other string that
-   * uniquely identifies this provider instance.
+   * A sensible value is a project key or any other string that uniquely identifies this provider.
    */
   cacheKeyPrefix?: string;
 };

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorCode } from '@openfeature/web-sdk';
+import { ErrorCode, type EvaluationContext } from '@openfeature/web-sdk';
 import { BulkEvaluationStatus } from './model/evaluate-flags-response';
 import { OFREPWebProvider } from './ofrep-web-provider';
 import TestLogger from '../../test/test-logger';
@@ -404,7 +404,7 @@ describe('OFREPWebProvider', () => {
     it('connects SSE after the background refresh following a local-cache-first cache hit', async () => {
       // Seed the cache so initialize() hits the cache-first path.
       const storage = new Storage('local-cache-first');
-      const key = await storage.getStorageKey(defaultContext.targetingKey);
+      const key = await storage.getStorageKey(endpointBaseURL, defaultContext);
       localStorage.setItem(
         key,
         JSON.stringify({
@@ -445,7 +445,7 @@ describe('OFREPWebProvider', () => {
       // and the server responds 304 (no body, no eventStreams), so SSE must be established
       // from the persisted configuration rather than from a 200 response.
       const storage = new Storage('local-cache-first');
-      const key = await storage.getStorageKey(defaultContext.targetingKey);
+      const key = await storage.getStorageKey(endpointBaseURL, defaultContext);
       localStorage.setItem(
         key,
         JSON.stringify({
@@ -825,14 +825,14 @@ describe('OFREPWebProvider', () => {
      * constructing a provider.
      */
     async function seedPersistentCache(
-      targetingKey: string,
+      context: EvaluationContext,
       cache: FlagCache,
       etag: string | null = null,
       writtenAt: Date = new Date(),
       metadata?: Record<string, unknown>,
     ): Promise<void> {
       const storage = new Storage('local-cache-first');
-      const key = await storage.getStorageKey(targetingKey);
+      const key = await storage.getStorageKey(endpointBaseURL, context);
       const entry: PersistedEntry = {
         version: 1,
         cacheKeyHash: key,
@@ -856,7 +856,7 @@ describe('OFREPWebProvider', () => {
 
     it('emits READY from persisted cache on init (cache-first), then refreshes from the network in the background', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
-      await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+      await seedPersistentCache(defaultContext, boolFlagCache);
       const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: -1 }, new TestLogger());
       await OpenFeature.setContext(defaultContext);
       OpenFeature.setProvider(providerName, provider);
@@ -876,7 +876,7 @@ describe('OFREPWebProvider', () => {
 
     it('refreshes from the network in the background after a cache hit when polling is enabled', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
-      await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+      await seedPersistentCache(defaultContext, boolFlagCache);
       const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: 50 }, new TestLogger());
       await OpenFeature.setContext(defaultContext);
       OpenFeature.setProvider(providerName, provider);
@@ -893,8 +893,8 @@ describe('OFREPWebProvider', () => {
     it('does not read or write localStorage when cacheMode is disabled', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
       const storage = new Storage('local-cache-first');
-      const seededKey = await storage.getStorageKey(defaultContext.targetingKey);
-      await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+      const seededKey = await storage.getStorageKey(endpointBaseURL, defaultContext);
+      await seedPersistentCache(defaultContext, boolFlagCache);
       expect(localStorage.getItem(seededKey)).not.toBeNull();
       const provider = new OFREPWebProvider(
         { baseUrl: endpointBaseURL, cacheMode: 'disabled', pollInterval: -1 },
@@ -915,7 +915,7 @@ describe('OFREPWebProvider', () => {
       const user2 = '22222222-2222-4222-8222-222222222222';
       const flagKey = 'per-user-cache-flag';
       const ctx = (targetingKey: string) => ({ ...defaultContext, targetingKey, perUserCacheTest: true });
-      await seedPersistentCache(user1, {
+      await seedPersistentCache(ctx(user1), {
         [flagKey]: {
           key: flagKey,
           value: { user: 1 },
@@ -923,7 +923,7 @@ describe('OFREPWebProvider', () => {
           reason: StandardResolutionReasons.STATIC,
         },
       });
-      await seedPersistentCache(user2, {
+      await seedPersistentCache(ctx(user2), {
         [flagKey]: {
           key: flagKey,
           value: { user: 2 },
@@ -949,9 +949,9 @@ describe('OFREPWebProvider', () => {
 
     it('keeps the persisted cache when a background fetch returns 401 (ADR 0009: TTL governs expiry, not auth errors)', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
-      await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+      await seedPersistentCache(defaultContext, boolFlagCache);
       const storage = new Storage('local-cache-first');
-      const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
+      const lsKey = await storage.getStorageKey(endpointBaseURL, defaultContext);
       expect(localStorage.getItem(lsKey)).not.toBeNull();
 
       server.use(
@@ -970,9 +970,9 @@ describe('OFREPWebProvider', () => {
 
     it('keeps the persisted cache when a background fetch returns 400 (ADR 0009: TTL governs expiry, not config errors)', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
-      await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+      await seedPersistentCache(defaultContext, boolFlagCache);
       const storage = new Storage('local-cache-first');
-      const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
+      const lsKey = await storage.getStorageKey(endpointBaseURL, defaultContext);
 
       server.use(
         http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () =>
@@ -992,10 +992,10 @@ describe('OFREPWebProvider', () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
       // Seed a cache entry that is already 31 days old (past the default 30-day TTL).
       const expiredDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
-      await seedPersistentCache(defaultContext.targetingKey, boolFlagCache, null, expiredDate);
+      await seedPersistentCache(defaultContext, boolFlagCache, null, expiredDate);
 
       const storage = new Storage('local-cache-first');
-      const lsKey = await storage.getStorageKey(defaultContext.targetingKey);
+      const lsKey = await storage.getStorageKey(endpointBaseURL, defaultContext);
       expect(localStorage.getItem(lsKey)).not.toBeNull(); // Exists before init.
 
       const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: -1 }, new TestLogger());
@@ -1017,7 +1017,7 @@ describe('OFREPWebProvider', () => {
 
     it('restores flag-set metadata from the persisted entry so FLAG_NOT_FOUND includes it on a cold cache start', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
-      await seedPersistentCache(defaultContext.targetingKey, boolFlagCache, null, new Date(), TEST_FLAG_SET_METADATA);
+      await seedPersistentCache(defaultContext, boolFlagCache, null, new Date(), TEST_FLAG_SET_METADATA);
 
       server.use(http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () => HttpResponse.error()));
 
@@ -1049,7 +1049,8 @@ describe('OFREPWebProvider', () => {
       await OpenFeature.setProviderAndWait(providerName, provider);
 
       const storage = new Storage('local-cache-first');
-      const user1Key = await storage.getStorageKey(user1);
+      const user1Context = { ...defaultContext, targetingKey: user1 };
+      const user1Key = await storage.getStorageKey(endpointBaseURL, user1Context);
       // After init, user1's entry should have been written by the network fetch.
       expect(localStorage.getItem(user1Key)).not.toBeNull();
 
@@ -1060,10 +1061,30 @@ describe('OFREPWebProvider', () => {
       expect(localStorage.getItem(user1Key)).toBeNull();
     });
 
+    it('clears the old persisted entry when context changes but targeting key stays the same', async () => {
+      const user1 = defaultContext.targetingKey;
+      const providerName = expect.getState().currentTestName || 'test-provider';
+
+      const user1Context = { ...defaultContext, targetingKey: user1, tenant: 'a' };
+      const user1ChangedContext = { ...defaultContext, targetingKey: user1, tenant: 'b' };
+      const provider = new OFREPWebProvider({ baseUrl: endpointBaseURL, pollInterval: -1 }, new TestLogger());
+      await OpenFeature.setContext(user1Context);
+      await OpenFeature.setProviderAndWait(providerName, provider);
+
+      const storage = new Storage('local-cache-first');
+      const user1Key = await storage.getStorageKey(endpointBaseURL, user1Context);
+      expect(localStorage.getItem(user1Key)).not.toBeNull();
+
+      await OpenFeature.setContext(user1ChangedContext);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(localStorage.getItem(user1Key)).toBeNull();
+    });
+
     describe('network-first', () => {
       it('blocks init on the network and serves fresh flags (STATIC, not CACHED) when the request succeeds', async () => {
         const providerName = expect.getState().currentTestName || 'test-provider';
-        await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+        await seedPersistentCache(defaultContext, boolFlagCache);
         const provider = new OFREPWebProvider(
           { baseUrl: endpointBaseURL, cacheMode: 'network-first', pollInterval: -1 },
           new TestLogger(),
@@ -1079,7 +1100,7 @@ describe('OFREPWebProvider', () => {
 
       it('falls back to the persisted cache on a transient network error and serves flags as CACHED', async () => {
         const providerName = expect.getState().currentTestName || 'test-provider';
-        await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+        await seedPersistentCache(defaultContext, boolFlagCache);
 
         server.use(http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () => HttpResponse.error()));
 
@@ -1098,7 +1119,7 @@ describe('OFREPWebProvider', () => {
 
       it('falls back to the persisted cache on a 500 server error and serves flags as CACHED', async () => {
         const providerName = expect.getState().currentTestName || 'test-provider';
-        await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+        await seedPersistentCache(defaultContext, boolFlagCache);
 
         server.use(
           http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () =>
@@ -1121,7 +1142,7 @@ describe('OFREPWebProvider', () => {
 
       it('surfaces the error immediately on a 400 with a valid error body without falling back to cache', async () => {
         const providerName = expect.getState().currentTestName || 'test-provider';
-        await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+        await seedPersistentCache(defaultContext, boolFlagCache);
 
         server.use(
           http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () =>
@@ -1139,7 +1160,7 @@ describe('OFREPWebProvider', () => {
 
       it('surfaces the error immediately on a 400 with no valid error body without falling back to cache', async () => {
         const providerName = expect.getState().currentTestName || 'test-provider';
-        await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+        await seedPersistentCache(defaultContext, boolFlagCache);
 
         server.use(
           http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () =>
@@ -1177,7 +1198,7 @@ describe('OFREPWebProvider', () => {
 
       it('surfaces a 401 as FATAL immediately and does not fall back to the persisted cache', async () => {
         const providerName = expect.getState().currentTestName || 'test-provider';
-        await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+        await seedPersistentCache(defaultContext, boolFlagCache);
 
         server.use(
           http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () =>
@@ -1202,7 +1223,7 @@ describe('OFREPWebProvider', () => {
 
       it('surfaces a 403 as FATAL immediately and does not fall back to the persisted cache', async () => {
         const providerName = expect.getState().currentTestName || 'test-provider';
-        await seedPersistentCache(defaultContext.targetingKey, boolFlagCache);
+        await seedPersistentCache(defaultContext, boolFlagCache);
 
         server.use(
           http.post('https://localhost:8080/ofrep/v1/evaluate/flags', () =>
@@ -1229,7 +1250,7 @@ describe('OFREPWebProvider', () => {
     it('restores the ETag from the persisted entry so background refresh uses If-None-Match', async () => {
       const providerName = expect.getState().currentTestName || 'test-provider';
       const storedEtag = '"abc123"';
-      await seedPersistentCache(defaultContext.targetingKey, boolFlagCache, storedEtag);
+      await seedPersistentCache(defaultContext, boolFlagCache, storedEtag);
 
       let capturedIfNoneMatch: string | null = null;
       server.use(

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -85,7 +85,12 @@ export class OFREPWebProvider implements Provider {
     this._pollingInterval = this._options.pollInterval ?? this.DEFAULT_POLL_INTERVAL;
     this._cacheMode = this._options.cacheMode ?? 'local-cache-first';
     this._cacheTTL = this._options.cacheTTL ?? DEFAULT_CACHE_TTL_SECONDS;
-    this._storage = new Storage(this._cacheMode, this._options.cacheKeyPrefix, logger);
+    this._storage = new Storage(
+      this._cacheMode,
+      this._options.cacheKeyPrefix,
+      this._options.cacheKeyTransformer,
+      this._logger,
+    );
     this._isUsingCache = false;
   }
 

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -176,9 +176,11 @@ export class OFREPWebProvider implements Provider {
   async onContextChange(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void> {
     this._contextRevision++;
     try {
-      if (oldContext?.targetingKey !== newContext?.targetingKey) {
+      const oldStorageKey = await this._storage.getStorageKey(this._options.baseUrl, oldContext);
+      const newStorageKey = await this._storage.getStorageKey(this._options.baseUrl, newContext);
+      if (oldStorageKey !== newStorageKey) {
         this._etag = null;
-        void this._storage.clear(oldContext?.targetingKey ?? '');
+        await this._storage.clear(this._options.baseUrl, oldContext);
       }
       this._context = newContext;
 
@@ -262,7 +264,7 @@ export class OFREPWebProvider implements Provider {
         throw error;
       }
       // Transient / server errors (5xx, network failures, timeouts) — try the persisted cache as a fallback.
-      const cached = await this._storage.retrieve(context?.targetingKey ?? '', this._cacheTTL);
+      const cached = await this._storage.retrieve(this._options.baseUrl, context, this._cacheTTL);
       if (!cached) {
         throw error; // No usable cache — propagate the original error.
       }
@@ -342,7 +344,8 @@ export class OFREPWebProvider implements Provider {
         typeof bulkSuccessResp.metadata === 'object' ? bulkSuccessResp.metadata : {},
       );
       await this._storage.store(
-        context?.targetingKey ?? '',
+        this._options.baseUrl,
+        context,
         newCache,
         newEtag,
         this._flagSetMetadataCache,
@@ -617,7 +620,7 @@ export class OFREPWebProvider implements Provider {
   }
 
   private async _tryLoadFlagsFromCache(context?: EvaluationContext | undefined): Promise<boolean> {
-    const cached = await this._storage.retrieve(context?.targetingKey ?? '', this._cacheTTL);
+    const cached = await this._storage.retrieve(this._options.baseUrl, context, this._cacheTTL);
     if (cached) {
       this._isUsingCache = true;
       this._flagCache = cached.flags;

--- a/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
@@ -1,6 +1,6 @@
 import type { FlagCache } from '../model/in-memory-cache';
 import { Storage } from './storage';
-import { StandardResolutionReasons } from '@openfeature/web-sdk';
+import { StandardResolutionReasons, type EvaluationContext } from '@openfeature/web-sdk';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { TEST_FLAG_METADATA } from '../../../../../shared/ofrep-core/src/test/test-constants';
 import { DEFAULT_CACHE_TTL_SECONDS } from '../model/ofrep-web-provider-options';
@@ -14,6 +14,13 @@ const boolFlagCache: FlagCache = {
   },
 };
 
+const baseUrl = 'https://localhost:8080';
+
+const defaultContext: EvaluationContext = {
+  targetingKey: 'user-pii-21640825-95e7-4335-b149-bd6881cf7875',
+  email: 'john.doe@openfeature.dev',
+};
+
 describe('Storage (persistent flag cache)', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -21,39 +28,50 @@ describe('Storage (persistent flag cache)', () => {
 
   it('uses a versioned storage key and does not embed the raw targeting key', async () => {
     const storage = new Storage('local-cache-first');
-    const targetingKey = 'user-pii-21640825-95e7-4335-b149-bd6881cf7875';
-    const key = await storage.getStorageKey(targetingKey);
+    const key = await storage.getStorageKey(baseUrl, defaultContext);
     expect(key.startsWith('ofrep-web-provider:v1:')).toBe(true);
-    expect(key).not.toContain(targetingKey);
+    expect(key).not.toContain(defaultContext.targetingKey ?? '');
   });
 
-  it('maps different targeting keys to different storage keys', async () => {
+  it('maps different contexts to different storage keys', async () => {
     const storage = new Storage('local-cache-first');
-    expect(await storage.getStorageKey('a')).not.toBe(await storage.getStorageKey('b'));
+    expect(await storage.getStorageKey(baseUrl, { targetingKey: 'a' })).not.toBe(
+      await storage.getStorageKey(baseUrl, { targetingKey: 'b' }),
+    );
+  });
+
+  it('maps identical contexts under different URLs to different storage keys', async () => {
+    const storage = new Storage('local-cache-first');
+    const context: EvaluationContext = { targetingKey: 'same-user', tenant: 'tenant-a' };
+    expect(await storage.getStorageKey('https://localhost:8080', context)).not.toBe(
+      await storage.getStorageKey('https://localhost:9090', context),
+    );
   });
 
   it('does not read or write when cacheMode is disabled', async () => {
     const storage = new Storage('disabled');
-    await storage.store('any-key', boolFlagCache, null);
+    const context: EvaluationContext = { targetingKey: 'any-key' };
+    await storage.store(baseUrl, context, boolFlagCache, null);
     expect(localStorage.length).toBe(0);
-    expect(await storage.retrieve('any-key', DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
+    expect(await storage.retrieve(baseUrl, context, DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
   });
 
-  it('clears the hashed entry for the given targeting key', async () => {
+  it('clears the hashed entry for the given URL and context', async () => {
     const storage = new Storage('local-cache-first');
-    const tk = 'clear-me';
-    await storage.store(tk, boolFlagCache, null);
-    const key = await storage.getStorageKey(tk);
+    const context: EvaluationContext = { targetingKey: 'clear-me' };
+    await storage.store(baseUrl, context, boolFlagCache, null);
+    const key = await storage.getStorageKey(baseUrl, context);
     expect(localStorage.getItem(key)).not.toBeNull();
-    await storage.clear(tk);
+    await storage.clear(baseUrl, context);
     expect(localStorage.getItem(key)).toBeNull();
   });
 
   it('stores and retrieves the flag cache and ETag in the persisted envelope', async () => {
     const storage = new Storage('local-cache-first');
     const etag = '"abc123"';
-    await storage.store('user-1', boolFlagCache, etag);
-    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    const context: EvaluationContext = { targetingKey: 'user-1' };
+    await storage.store(baseUrl, context, boolFlagCache, etag);
+    const result = await storage.retrieve(baseUrl, context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result).not.toBeUndefined();
     expect(result!.flags).toEqual(boolFlagCache);
     expect(result!.etag).toBe(etag);
@@ -62,37 +80,40 @@ describe('Storage (persistent flag cache)', () => {
   it('stores and retrieves the SSE event streams in the persisted envelope', async () => {
     const storage = new Storage('local-cache-first');
     const eventStreams = [{ type: 'sse' as const, url: 'https://sse.example.com/stream' }];
-    await storage.store('user-1', boolFlagCache, '"etag"', undefined, eventStreams);
-    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    const context: EvaluationContext = { targetingKey: 'user-1' };
+    await storage.store(baseUrl, context, boolFlagCache, '"etag"', undefined, eventStreams);
+    const result = await storage.retrieve(baseUrl, context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result!.eventStreams).toEqual(eventStreams);
   });
 
   it('omits event streams from the envelope when none are provided', async () => {
     const storage = new Storage('local-cache-first');
-    await storage.store('user-1', boolFlagCache, '"etag"');
-    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    const context: EvaluationContext = { targetingKey: 'user-1' };
+    await storage.store(baseUrl, context, boolFlagCache, '"etag"');
+    const result = await storage.retrieve(baseUrl, context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result!.eventStreams).toBeUndefined();
   });
 
   it('stores null ETag when none is provided', async () => {
     const storage = new Storage('local-cache-first');
-    await storage.store('user-1', boolFlagCache, null);
-    const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+    const context: EvaluationContext = { targetingKey: 'user-1' };
+    await storage.store(baseUrl, context, boolFlagCache, null);
+    const result = await storage.retrieve(baseUrl, context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result!.etag).toBeNull();
   });
 
   it('returns undefined for an expired entry and removes it from storage', async () => {
     const storage = new Storage('local-cache-first');
-    const tk = 'user-expired';
-    await storage.store(tk, boolFlagCache, null);
+    const context: EvaluationContext = { targetingKey: 'user-expired' };
+    await storage.store(baseUrl, context, boolFlagCache, null);
 
     // Patch the writtenAt to be 31 days ago.
-    const key = await storage.getStorageKey(tk);
+    const key = await storage.getStorageKey(baseUrl, context);
     const raw = JSON.parse(localStorage.getItem(key)!);
     raw.writtenAt = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
     localStorage.setItem(key, JSON.stringify(raw));
 
-    const result = await storage.retrieve(tk, DEFAULT_CACHE_TTL_SECONDS);
+    const result = await storage.retrieve(baseUrl, context, DEFAULT_CACHE_TTL_SECONDS);
     expect(result).toBeUndefined();
     // Expired entry should have been evicted.
     expect(localStorage.getItem(key)).toBeNull();
@@ -100,23 +121,25 @@ describe('Storage (persistent flag cache)', () => {
 
   it('returns undefined for an entry with an unknown schema version', async () => {
     const storage = new Storage('local-cache-first');
-    const tk = 'user-v99';
-    await storage.store(tk, boolFlagCache, null);
-    const key = await storage.getStorageKey(tk);
+    const context: EvaluationContext = { targetingKey: 'user-v99' };
+    await storage.store(baseUrl, context, boolFlagCache, null);
+    const key = await storage.getStorageKey(baseUrl, context);
     const raw = JSON.parse(localStorage.getItem(key)!);
     raw.version = 99;
     localStorage.setItem(key, JSON.stringify(raw));
-    expect(await storage.retrieve(tk, DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
+    expect(await storage.retrieve(baseUrl, context, DEFAULT_CACHE_TTL_SECONDS)).toBeUndefined();
   });
 
   it('uses a different hash when cacheKeyPrefix is set, preventing key collisions', async () => {
     const storageA = new Storage('local-cache-first', 'provider-a');
     const storageB = new Storage('local-cache-first', 'provider-b');
     const storageNoPrefix = new Storage('local-cache-first');
-    const tk = 'same-user';
-    // All three should produce different storage keys for the same targeting key.
-    expect(await storageA.getStorageKey(tk)).not.toBe(await storageB.getStorageKey(tk));
-    expect(await storageA.getStorageKey(tk)).not.toBe(await storageNoPrefix.getStorageKey(tk));
+    const context: EvaluationContext = { targetingKey: 'same-user' };
+    // All three should produce different storage keys for the same URL+context.
+    expect(await storageA.getStorageKey(baseUrl, context)).not.toBe(await storageB.getStorageKey(baseUrl, context));
+    expect(await storageA.getStorageKey(baseUrl, context)).not.toBe(
+      await storageNoPrefix.getStorageKey(baseUrl, context),
+    );
   });
 
   describe('when crypto.subtle is unavailable (non-secure context)', () => {
@@ -132,22 +155,27 @@ describe('Storage (persistent flag cache)', () => {
 
     it('produces a valid versioned storage key without the raw targeting key', async () => {
       const storage = new Storage('local-cache-first');
-      const tk = 'user-pii-21640825-95e7-4335-b149-bd6881cf7875';
-      const key = await storage.getStorageKey(tk);
+      const context: EvaluationContext = {
+        targetingKey: 'user-pii-21640825-95e7-4335-b149-bd6881cf7875',
+      };
+      const key = await storage.getStorageKey(baseUrl, context);
       expect(key.startsWith('ofrep-web-provider:v1:')).toBe(true);
-      expect(key).not.toContain(tk);
+      expect(key).not.toContain(context.targetingKey ?? '');
       expect(key.split(':')[2]).toMatch(/^[0-9a-f]{16}$/);
     });
 
-    it('maps different targeting keys to different storage keys', async () => {
+    it('maps different contexts to different storage keys', async () => {
       const storage = new Storage('local-cache-first');
-      expect(await storage.getStorageKey('a')).not.toBe(await storage.getStorageKey('b'));
+      expect(await storage.getStorageKey(baseUrl, { targetingKey: 'a' })).not.toBe(
+        await storage.getStorageKey(baseUrl, { targetingKey: 'b' }),
+      );
     });
 
     it('stores and retrieves flags without throwing', async () => {
       const storage = new Storage('local-cache-first');
-      await storage.store('user-1', boolFlagCache, '"etag"');
-      const result = await storage.retrieve('user-1', DEFAULT_CACHE_TTL_SECONDS);
+      const context: EvaluationContext = { targetingKey: 'user-1' };
+      await storage.store(baseUrl, context, boolFlagCache, '"etag"');
+      const result = await storage.retrieve(baseUrl, context, DEFAULT_CACHE_TTL_SECONDS);
       expect(result).not.toBeUndefined();
       expect(result!.flags).toEqual(boolFlagCache);
       expect(result!.etag).toBe('"etag"');

--- a/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.spec.ts
@@ -142,6 +142,20 @@ describe('Storage (persistent flag cache)', () => {
     );
   });
 
+  it('produces the same cache key for contexts that differ only in a field omitted by cacheKeyTransformer', async () => {
+    // The transformer strips the volatile `session` field so two contexts that share
+    // the same `targetingKey` but differ only in `session` are treated as equivalent.
+    const transformer = (ctx: EvaluationContext | undefined): EvaluationContext | undefined => {
+      if (!ctx) return ctx;
+      const { session: _omit, ...rest } = ctx as EvaluationContext & { session?: unknown };
+      return rest;
+    };
+    const storage = new Storage('local-cache-first', undefined, transformer);
+    const contextA: EvaluationContext = { targetingKey: 'user-1', session: 'sess-aaa' };
+    const contextB: EvaluationContext = { targetingKey: 'user-1', session: 'sess-bbb' };
+    expect(await storage.getStorageKey(baseUrl, contextA)).toBe(await storage.getStorageKey(baseUrl, contextB));
+  });
+
   describe('when crypto.subtle is unavailable (non-secure context)', () => {
     let subtleSpy: jest.SpyInstance;
 

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -13,7 +13,8 @@ const STORAGE_NS = 'ofrep-web-provider';
 export interface PersistedEntry {
   /** Schema version — used to discard entries written by older provider versions. */
   version: number;
-  /** Hex digest (16 chars) of `targetingKey` (or `cacheKeyPrefix + ":" + targetingKey` when configured). SHA-256 when crypto.subtle is available, FNV-1a fallback otherwise. */
+  /** Hex digest (16 chars) of `baseUrl + ":" + context` (or `cacheKeyPrefix + ":" + baseUrl + ":" + context` when configured).
+   *  SHA-256 when crypto.subtle is available, FNV-1a fallback otherwise. */
   cacheKeyHash: string;
   /** ETag returned by the server for this evaluation, used for efficient revalidation. */
   etag: string | null;
@@ -43,12 +44,12 @@ export class Storage {
   }
 
   /**
-   * Hashes the URL + evaluation context (with optional prefix) to a 16-char hex string.
+   * Hashes the base URL + evaluation context (with optional prefix) to a 16-char hex string.
    * Uses SHA-256 via crypto.subtle when available (secure contexts).
    * Falls back to a double-pass FNV-1a-32 in non-secure contexts where crypto.subtle is absent.
    */
-  private async _hashInput(url: string, context: EvaluationContext | undefined): Promise<string> {
-    const input = [this._cacheKeyPrefix ?? '', url, context ? JSON.stringify(context) : ''].join(':');
+  private async _hashInput(baseUrl: string, context: EvaluationContext | undefined): Promise<string> {
+    const input = [this._cacheKeyPrefix ?? '', baseUrl, context ? JSON.stringify(context) : ''].join(':');
     if (typeof crypto !== 'undefined' && crypto.subtle) {
       const encoded = new TextEncoder().encode(input);
       const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
@@ -80,11 +81,11 @@ export class Storage {
   }
 
   /**
-   * Returns the localStorage key for the given URL + evaluation context.
+   * Returns the localStorage key for the given base URL + evaluation context.
    * Format: `ofrep-web-provider:v{version}:{hash}`
    */
-  async getStorageKey(url: string, context: EvaluationContext | undefined): Promise<string> {
-    return `${STORAGE_NS}:v${SCHEMA_VERSION}:${await this._hashInput(url, context)}`;
+  async getStorageKey(baseUrl: string, context: EvaluationContext | undefined): Promise<string> {
+    return `${STORAGE_NS}:v${SCHEMA_VERSION}:${await this._hashInput(baseUrl, context)}`;
   }
 
   /**
@@ -93,7 +94,7 @@ export class Storage {
    * so the provider continues operating with the fresh in-memory values.
    */
   async store(
-    url: string,
+    baseUrl: string,
     context: EvaluationContext | undefined,
     flags: FlagCache,
     etag: string | null,
@@ -101,10 +102,10 @@ export class Storage {
     eventStreams?: EventStream[],
   ): Promise<void> {
     if (this._disabled) return;
-    const key = await this.getStorageKey(url, context);
+    const key = await this.getStorageKey(baseUrl, context);
     const entry: PersistedEntry = {
       version: SCHEMA_VERSION,
-      cacheKeyHash: await this._hashInput(url, context),
+      cacheKeyHash: await this._hashInput(baseUrl, context),
       etag,
       writtenAt: new Date().toISOString(),
       data: flags,
@@ -122,12 +123,12 @@ export class Storage {
    * Loads a previously persisted entry.
    * Returns `undefined` when:
    *  - cacheMode is 'disabled'
-   *  - no entry exists for this targeting key
+   *  - no entry exists for this base URL + evaluation context
    *  - the schema version does not match
    *  - the entry is older than `ttlSeconds` (expired entries are removed from storage)
    */
   async retrieve(
-    url: string,
+    baseUrl: string,
     context: EvaluationContext | undefined,
     ttlSeconds: number,
   ): Promise<
@@ -136,7 +137,7 @@ export class Storage {
   > {
     if (this._disabled) return undefined;
     try {
-      const raw = localStorage.getItem(await this.getStorageKey(url, context));
+      const raw = localStorage.getItem(await this.getStorageKey(baseUrl, context));
       if (!raw) return undefined;
 
       const entry = JSON.parse(raw) as PersistedEntry;
@@ -147,7 +148,7 @@ export class Storage {
       // Enforce TTL — treat expired entries as a cache miss and evict them.
       const writtenAt = new Date(entry.writtenAt).getTime();
       if (Number.isNaN(writtenAt) || Date.now() - writtenAt > ttlSeconds * 1000) {
-        await this.clear(url, context);
+        await this.clear(baseUrl, context);
         return undefined;
       }
 
@@ -159,13 +160,13 @@ export class Storage {
   }
 
   /**
-   * Removes the persisted entry for the given URL + evaluation context.
+   * Removes the persisted entry for the given base URL + evaluation context.
    * No-op when cacheMode is 'disabled'.
    */
-  async clear(url: string, context: EvaluationContext | undefined): Promise<void> {
+  async clear(baseUrl: string, context: EvaluationContext | undefined): Promise<void> {
     if (this._disabled) return;
     try {
-      localStorage.removeItem(await this.getStorageKey(url, context));
+      localStorage.removeItem(await this.getStorageKey(baseUrl, context));
     } catch (error) {
       this._logger?.error(`Error clearing flag cache from local storage: ${error}`);
     }

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -31,11 +31,18 @@ export interface PersistedEntry {
 export class Storage {
   private readonly _disabled: boolean;
   private readonly _cacheKeyPrefix?: string;
+  private readonly _cacheKeyTransformer: (context: EvaluationContext | undefined) => EvaluationContext | undefined;
   private readonly _logger?: Logger;
 
-  constructor(cacheMode: CacheMode = 'local-cache-first', cacheKeyPrefix?: string, logger?: Logger) {
+  constructor(
+    cacheMode: CacheMode = 'local-cache-first',
+    cacheKeyPrefix?: string,
+    cacheKeyTransformer?: (context: EvaluationContext | undefined) => EvaluationContext | undefined,
+    logger?: Logger,
+  ) {
     this._disabled = cacheMode === 'disabled';
     this._cacheKeyPrefix = cacheKeyPrefix;
+    this._cacheKeyTransformer = cacheKeyTransformer ?? ((context) => context);
     this._logger = logger;
   }
 
@@ -49,7 +56,11 @@ export class Storage {
    * Falls back to a double-pass FNV-1a-32 in non-secure contexts where crypto.subtle is absent.
    */
   private async _hashInput(baseUrl: string, context: EvaluationContext | undefined): Promise<string> {
-    const input = [this._cacheKeyPrefix ?? '', baseUrl, context ? JSON.stringify(context) : ''].join(':');
+    const input = [
+      this._cacheKeyPrefix ?? '',
+      baseUrl,
+      context ? JSON.stringify(this._cacheKeyTransformer(context)) : '',
+    ].join(':');
     if (typeof crypto !== 'undefined' && crypto.subtle) {
       const encoded = new TextEncoder().encode(input);
       const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);

--- a/libs/providers/ofrep-web/src/lib/store/storage.ts
+++ b/libs/providers/ofrep-web/src/lib/store/storage.ts
@@ -1,5 +1,5 @@
 import type { EventStream } from '@openfeature/ofrep-core';
-import type { Logger } from '@openfeature/web-sdk';
+import type { EvaluationContext, Logger } from '@openfeature/web-sdk';
 import type { FlagCache } from '../model/in-memory-cache';
 import type { CacheMode } from '../model/ofrep-web-provider-options';
 
@@ -43,12 +43,12 @@ export class Storage {
   }
 
   /**
-   * Hashes the targeting key (with optional prefix) to a 16-char hex string.
+   * Hashes the URL + evaluation context (with optional prefix) to a 16-char hex string.
    * Uses SHA-256 via crypto.subtle when available (secure contexts).
    * Falls back to a double-pass FNV-1a-32 in non-secure contexts where crypto.subtle is absent.
    */
-  private async _hashInput(targetingKey: string): Promise<string> {
-    const input = this._cacheKeyPrefix ? `${this._cacheKeyPrefix}:${targetingKey}` : targetingKey;
+  private async _hashInput(url: string, context: EvaluationContext | undefined): Promise<string> {
+    const input = [this._cacheKeyPrefix ?? '', url, context ? JSON.stringify(context) : ''].join(':');
     if (typeof crypto !== 'undefined' && crypto.subtle) {
       const encoded = new TextEncoder().encode(input);
       const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
@@ -80,11 +80,11 @@ export class Storage {
   }
 
   /**
-   * Returns the localStorage key for the given targeting key.
+   * Returns the localStorage key for the given URL + evaluation context.
    * Format: `ofrep-web-provider:v{version}:{hash}`
    */
-  async getStorageKey(targetingKey: string): Promise<string> {
-    return `${STORAGE_NS}:v${SCHEMA_VERSION}:${await this._hashInput(targetingKey)}`;
+  async getStorageKey(url: string, context: EvaluationContext | undefined): Promise<string> {
+    return `${STORAGE_NS}:v${SCHEMA_VERSION}:${await this._hashInput(url, context)}`;
   }
 
   /**
@@ -93,17 +93,18 @@ export class Storage {
    * so the provider continues operating with the fresh in-memory values.
    */
   async store(
-    targetingKey: string,
+    url: string,
+    context: EvaluationContext | undefined,
     flags: FlagCache,
     etag: string | null,
     metadata?: Record<string, unknown>,
     eventStreams?: EventStream[],
   ): Promise<void> {
     if (this._disabled) return;
-    const key = await this.getStorageKey(targetingKey);
+    const key = await this.getStorageKey(url, context);
     const entry: PersistedEntry = {
       version: SCHEMA_VERSION,
-      cacheKeyHash: await this._hashInput(targetingKey),
+      cacheKeyHash: await this._hashInput(url, context),
       etag,
       writtenAt: new Date().toISOString(),
       data: flags,
@@ -126,7 +127,8 @@ export class Storage {
    *  - the entry is older than `ttlSeconds` (expired entries are removed from storage)
    */
   async retrieve(
-    targetingKey: string,
+    url: string,
+    context: EvaluationContext | undefined,
     ttlSeconds: number,
   ): Promise<
     | { flags: FlagCache; etag: string | null; metadata?: Record<string, unknown>; eventStreams?: EventStream[] }
@@ -134,7 +136,7 @@ export class Storage {
   > {
     if (this._disabled) return undefined;
     try {
-      const raw = localStorage.getItem(await this.getStorageKey(targetingKey));
+      const raw = localStorage.getItem(await this.getStorageKey(url, context));
       if (!raw) return undefined;
 
       const entry = JSON.parse(raw) as PersistedEntry;
@@ -145,7 +147,7 @@ export class Storage {
       // Enforce TTL — treat expired entries as a cache miss and evict them.
       const writtenAt = new Date(entry.writtenAt).getTime();
       if (Number.isNaN(writtenAt) || Date.now() - writtenAt > ttlSeconds * 1000) {
-        await this.clear(targetingKey);
+        await this.clear(url, context);
         return undefined;
       }
 
@@ -157,13 +159,13 @@ export class Storage {
   }
 
   /**
-   * Removes the persisted entry for the given targeting key.
+   * Removes the persisted entry for the given URL + evaluation context.
    * No-op when cacheMode is 'disabled'.
    */
-  async clear(targetingKey: string): Promise<void> {
+  async clear(url: string, context: EvaluationContext | undefined): Promise<void> {
     if (this._disabled) return;
     try {
-      localStorage.removeItem(await this.getStorageKey(targetingKey));
+      localStorage.removeItem(await this.getStorageKey(url, context));
     } catch (error) {
       this._logger?.error(`Error clearing flag cache from local storage: ${error}`);
     }


### PR DESCRIPTION
## This PR

Updates the cache key logic to use the base URL + full evaluation context. This ensures that two OFREP providers with different URLs or evaluation contexts but the same targeting key do not attempt to share a cache key, as they may have different flag results.

### Related Issues

N/A

### Notes

As caching is implemented at the provider level, rather than the SDK level, this breaks out of the isolation that the domain paradigm usually gives, especially in micro-frontend setups. So, we need to be very careful to make sure that two providers running at the same time are truly independent of each other unless they are doing exactly the same thing.

### Follow-up Tasks

N/A

### How to test

Test suite updated, ensure caching still works from an end-user perspective as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local cache persistence so storage entries are keyed by the endpoint base URL and the full evaluation context, preventing collisions across context changes.
  * When the evaluation context changes (even if the targeting key stays the same), previously persisted cached state is now cleared to avoid stale ETag/flags reuse.
* **New Features**
  * Added an optional `cacheKeyTransformer` option to customize (or omit) parts of the evaluation context used for cache key generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->