### PR TITLE
fix(launchdarkly): handle null attributes in evaluation context

### DIFF
--- a/libs/providers/launchdarkly-client/src/lib/translate-context.spec.ts
+++ b/libs/providers/launchdarkly-client/src/lib/translate-context.spec.ts
@@ -107,6 +107,42 @@ describe('translateContext', () => {
     expect(logger.logs.length).toEqual(0);
   });
 
+  it('accepts null custom attributes', () => {
+    const logger = new TestLogger();
+    expect(
+      translateContext(logger, {
+        targetingKey: 'the-key',
+        nullAttr: null,
+        nested: { nullAttr: null, other: 'value' },
+      }),
+    ).toEqual({
+      key: 'the-key',
+      kind: 'user',
+      nullAttr: null,
+      nested: { nullAttr: null, other: 'value' },
+    });
+    expect(logger.logs.length).toEqual(0);
+  });
+
+  it('logs an error for a null top-level attribute in a multi-kind context', () => {
+    const logger = new TestLogger();
+    expect(
+      translateContext(logger, {
+        kind: 'multi',
+        organization: null,
+        user: {
+          targetingKey: 'my-user-key',
+        },
+      }),
+    ).toEqual({
+      kind: 'multi',
+      user: {
+        key: 'my-user-key',
+      },
+    });
+    expect(logger.logs[0]).toEqual('Top level attributes in a multi-kind context should be Structure types.');
+  });
+
   it('converts date to ISO strings', () => {
     const date = new Date();
     const logger = new TestLogger();

--- a/libs/providers/launchdarkly-client/src/lib/translate-context.ts
+++ b/libs/providers/launchdarkly-client/src/lib/translate-context.ts
@@ -47,7 +47,7 @@ function convertAttributes(logger: LDLogger, key: string, value: any, object: an
   if (value instanceof Date) {
     // eslint-disable-next-line no-param-reassign
     object[key] = value.toISOString();
-  } else if (typeof value === 'object' && !Array.isArray(value)) {
+  } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
     // eslint-disable-next-line no-param-reassign
     object[key] = {};
     Object.entries(value).forEach(([objectKey, objectValue]) => {
@@ -132,7 +132,7 @@ export default function translateContext(logger: LDLogger, evalContext: Evaluati
     return Object.entries(evalContext).reduce((acc: any, [key, value]: [string, EvaluationContextValue]) => {
       if (key === 'kind') {
         acc.kind = value;
-      } else if (typeof value === 'object' && !Array.isArray(value)) {
+      } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
         const valueRecord = value as Record<string, EvaluationContextValue>;
         acc[key] = translateContextCommon(logger, valueRecord, valueRecord['targetingKey'] as string);
       } else {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This provider throws with errors like 

```
Error running launchdarkly-client-provider's context change handler: Object.entries requires that input parameter not be null or undefined
TypeError: Object.entries requires that input parameter not be null or undefined
```
Because the provider doesn't handle null values

Fixes #1573


