### PR TITLE
feat(azure-app-configuration): add Azure App Configuration provider

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -5,6 +5,8 @@ components:
     - toddbaert
   libs/providers/aws-ssm:
     - gdegiorgio
+  libs/providers/azure-app-configuration:
+    - wilqq
   libs/providers/config-cat:
     - lukas-reining
     - adams85

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -24,5 +24,6 @@
   "libs/providers/aws-ssm": "0.1.3",
   "libs/providers/flagsmith": "0.1.2",
   "libs/hooks/debounce": "0.1.1",
-  "libs/providers/localstorage": "0.1.2"
+  "libs/providers/localstorage": "0.1.2",
+  "libs/providers/azure-app-configuration": "0.1.0"
 }

--- a/libs/providers/azure-app-configuration/.eslintrc.json
+++ b/libs/providers/azure-app-configuration/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../../.eslintrc.json",
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/libs/providers/azure-app-configuration/README.md
+++ b/libs/providers/azure-app-configuration/README.md
@@ -1,0 +1,96 @@
+# Azure App Configuration Provider
+
+## What is Azure App Configuration?
+
+[Azure App Configuration](https://learn.microsoft.com/azure/azure-app-configuration/overview) is a managed service that provides a central place to manage application settings and feature flags. Its feature management capabilities support simple on/off toggles as well as advanced scenarios such as targeting, time windows, percentage rollouts, and variant feature flags.
+
+This provider lets OpenFeature applications resolve feature flags stored in Azure App Configuration. Under the hood it uses the official [`@azure/app-configuration-provider`](https://www.npmjs.com/package/@azure/app-configuration-provider) to load and refresh feature flags, and [`@microsoft/feature-management`](https://www.npmjs.com/package/@microsoft/feature-management) to evaluate them.
+
+## Installation
+
+```
+$ npm install @openfeature/azure-app-configuration-provider @azure/identity
+```
+
+`@openfeature/server-sdk` and `@azure/identity` are peer dependencies. Install `@azure/identity` if you authenticate with a token credential (recommended). It is not required when authenticating with a connection string.
+
+## Usage
+
+The provider is a server-side provider. Register it with OpenFeature and wait for it to become ready.
+
+### Using a Microsoft Entra ID token credential (recommended)
+
+```typescript
+import { OpenFeature } from '@openfeature/server-sdk';
+import { AzureAppConfigurationProvider } from '@openfeature/azure-app-configuration-provider';
+import { DefaultAzureCredential } from '@azure/identity';
+
+const provider = new AzureAppConfigurationProvider({
+  endpoint: 'https://<your-store>.azconfig.io',
+  credential: new DefaultAzureCredential(),
+});
+
+await OpenFeature.setProviderAndWait(provider);
+
+const client = OpenFeature.getClient();
+const isEnabled = await client.getBooleanValue('Beta', false);
+```
+
+### Using a connection string
+
+```typescript
+import { OpenFeature } from '@openfeature/server-sdk';
+import { AzureAppConfigurationProvider } from '@openfeature/azure-app-configuration-provider';
+
+const provider = new AzureAppConfigurationProvider({
+  connectionString: process.env.AZURE_APPCONFIG_CONNECTION_STRING!,
+});
+
+await OpenFeature.setProviderAndWait(provider);
+```
+
+## Configuration
+
+Provide exactly one of `connectionString` or `endpoint` + `credential`.
+
+| Property              | Type                | Description                                                                                                     | Default                |
+| --------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `connectionString`    | `string`            | Connection string for the Azure App Configuration store. Mutually exclusive with `endpoint`/`credential`.       | —                      |
+| `endpoint`            | `string`            | Endpoint URL of the Azure App Configuration store. Requires `credential`.                                       | —                      |
+| `credential`          | `TokenCredential`   | Token credential (e.g. `DefaultAzureCredential`) used with `endpoint`.                                          | —                      |
+| `selectors`           | `SettingSelector[]` | Feature flag selectors (`keyFilter`, `labelFilter`, ...) used to filter which feature flags are loaded.         | `[{ keyFilter: '*' }]` |
+| `enableRefresh`       | `boolean`           | Whether to periodically refresh feature flags and emit `ConfigurationChanged` events when a change is detected. | `true`                 |
+| `refreshIntervalInMs` | `number`            | Polling interval (in milliseconds) used to refresh feature flags. Must be greater than 1000.                    | `30000`                |
+
+## Flag resolution semantics
+
+Azure App Configuration feature flags map onto OpenFeature evaluation methods as follows:
+
+- **Boolean** (`getBooleanValue`): resolves the feature flag's enabled state via `FeatureManager.isEnabled`. This honors any configured feature filters (targeting, time window, percentage rollout, etc.).
+- **String / Number / Object** (`getStringValue`, `getNumberValue`, `getObjectValue`): resolve [variant feature flags](https://learn.microsoft.com/azure/azure-app-configuration/howto-variant-feature-flags-javascript) via `FeatureManager.getVariant`. The variant's `configuration` value is returned, and the variant name is exposed as the resolution `variant`. If no variant is assigned, the provided default value is returned with reason `DEFAULT`. A `TypeMismatchError` is raised if the variant configuration does not match the requested type.
+
+### Targeting context
+
+The OpenFeature evaluation context is mapped to the Azure feature-management targeting context:
+
+- `targetingKey` maps to `userId`.
+- a `groups` attribute (array of strings) maps to `groups`.
+
+```typescript
+const variant = await client.getStringValue('Greeting', 'Hello', {
+  targetingKey: 'user-123',
+  groups: ['beta-testers'],
+});
+```
+
+## Events
+
+When `enableRefresh` is `true`, the provider polls Azure App Configuration on `refreshIntervalInMs` and emits `ProviderEvents.ConfigurationChanged` whenever a refresh detects a change to the selected feature flags.
+
+## Building
+
+Run `nx package azure-app-configuration` to build the library.
+
+## Running unit tests
+
+Run `nx test azure-app-configuration` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/providers/azure-app-configuration/babel.config.json
+++ b/libs/providers/azure-app-configuration/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": [["minify", { "builtIns": false }]]
+}

--- a/libs/providers/azure-app-configuration/jest.config.cts
+++ b/libs/providers/azure-app-configuration/jest.config.cts
@@ -1,0 +1,10 @@
+module.exports = {
+  displayName: 'azure-app-configuration',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/providers/azure-app-configuration',
+};

--- a/libs/providers/azure-app-configuration/package.json
+++ b/libs/providers/azure-app-configuration/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@openfeature/azure-app-configuration-provider",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-feature/js-sdk-contrib.git",
+    "directory": "libs/providers/azure-app-configuration"
+  },
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "@azure/app-configuration-provider": "^2.5.1",
+    "@microsoft/feature-management": "^2.3.1",
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
+    "current-version": "echo $npm_package_version"
+  },
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@azure/identity": "^4.0.0",
+    "@openfeature/server-sdk": "^1.17.0"
+  },
+  "devDependencies": {
+    "@azure/identity": "^4.13.1"
+  }
+}

--- a/libs/providers/azure-app-configuration/package.json
+++ b/libs/providers/azure-app-configuration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfeature/azure-app-configuration-provider",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/open-feature/js-sdk-contrib.git",

--- a/libs/providers/azure-app-configuration/project.json
+++ b/libs/providers/azure-app-configuration/project.json
@@ -1,0 +1,76 @@
+{
+  "name": "azure-app-configuration",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/providers/azure-app-configuration/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "currentVersionResolver": "git-tag",
+      "fallbackCurrentVersionResolver": "disk"
+    }
+  },
+  "tags": [],
+  "targets": {
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "{projectRoot}/jest.config.cts"
+      }
+    },
+    "package": {
+      "executor": "@nx/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "project": "libs/providers/azure-app-configuration/package.json",
+        "outputPath": "dist/libs/providers/azure-app-configuration",
+        "entryFile": "libs/providers/azure-app-configuration/src/index.ts",
+        "tsConfig": "libs/providers/azure-app-configuration/tsconfig.lib.json",
+        "compiler": "tsc",
+        "generateExportsField": true,
+        "umdName": "azure-app-configuration",
+        "external": "all",
+        "format": ["cjs", "esm"],
+        "assets": [
+          {
+            "glob": "package.json",
+            "input": "./assets",
+            "output": "./src/"
+          },
+          {
+            "glob": "LICENSE",
+            "input": "./",
+            "output": "./"
+          },
+          {
+            "glob": "README.md",
+            "input": "./libs/providers/azure-app-configuration",
+            "output": "./"
+          }
+        ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run publish-if-not-exists",
+        "cwd": "dist/libs/providers/azure-app-configuration"
+      },
+      "dependsOn": [
+        {
+          "projects": "self",
+          "target": "package"
+        }
+      ]
+    }
+  }
+}

--- a/libs/providers/azure-app-configuration/src/index.ts
+++ b/libs/providers/azure-app-configuration/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/azure-app-configuration-provider';
+export * from './lib/types';

--- a/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.spec.ts
+++ b/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.spec.ts
@@ -282,7 +282,7 @@ describe('AzureAppConfigurationProvider', () => {
       expect(result).toEqual({ value: config, variant: 'Theme', reason: StandardResolutionReasons.DEFAULT });
     });
 
-    it('returns FLAG_NOT_FOUND when no variant is assigned', async () => {
+    it('returns the caller default with reason DEFAULT when no variant is assigned', async () => {
       const provider = await createProvider();
       getVariant.mockResolvedValue(undefined);
 
@@ -290,13 +290,11 @@ describe('AzureAppConfigurationProvider', () => {
 
       expect(result).toEqual({
         value: 'fallback',
-        reason: StandardResolutionReasons.ERROR,
-        errorCode: ErrorCode.FLAG_NOT_FOUND,
-        errorMessage: "Flag 'Greeting' was not found.",
+        reason: StandardResolutionReasons.DEFAULT,
       });
     });
 
-    it('returns FLAG_NOT_FOUND when the variant has no configuration', async () => {
+    it('returns the caller default with reason DEFAULT when the variant has no configuration', async () => {
       const provider = await createProvider();
       getVariant.mockResolvedValue(variant('Empty', undefined));
 
@@ -304,9 +302,7 @@ describe('AzureAppConfigurationProvider', () => {
 
       expect(result).toEqual({
         value: 7,
-        reason: StandardResolutionReasons.ERROR,
-        errorCode: ErrorCode.FLAG_NOT_FOUND,
-        errorMessage: "Flag 'Price' was not found.",
+        reason: StandardResolutionReasons.DEFAULT,
       });
     });
 

--- a/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.spec.ts
+++ b/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.spec.ts
@@ -1,0 +1,339 @@
+import {
+  ErrorCode,
+  ProviderEvents,
+  ProviderNotReadyError,
+  StandardResolutionReasons,
+  TypeMismatchError,
+} from '@openfeature/server-sdk';
+import { load } from '@azure/app-configuration-provider';
+import { ConfigurationMapFeatureFlagProvider, FeatureManager } from '@microsoft/feature-management';
+
+const variant = (name: string, configuration: unknown) => ({ name, configuration });
+import { AzureAppConfigurationProvider } from './azure-app-configuration-provider';
+import type { AzureAppConfigurationProviderConfig } from './types';
+
+jest.mock('@azure/app-configuration-provider', () => {
+  const actual = jest.requireActual('@azure/app-configuration-provider');
+  return {
+    ...actual,
+    load: jest.fn(),
+  };
+});
+
+jest.mock('@microsoft/feature-management', () => {
+  const actual = jest.requireActual('@microsoft/feature-management');
+  return {
+    ...actual,
+    FeatureManager: jest.fn(),
+    ConfigurationMapFeatureFlagProvider: jest.fn(),
+  };
+});
+
+const loadMock = load as jest.Mock;
+const FeatureManagerMock = FeatureManager as unknown as jest.Mock;
+const ConfigurationMapFeatureFlagProviderMock = ConfigurationMapFeatureFlagProvider as unknown as jest.Mock;
+
+describe('AzureAppConfigurationProvider', () => {
+  const isEnabled = jest.fn();
+  const getVariant = jest.fn();
+  const getFeatureFlag = jest.fn().mockResolvedValue({ id: 'flag', enabled: true });
+  const refresh = jest.fn().mockResolvedValue(undefined);
+  const dispose = jest.fn();
+  let onRefreshListener: (() => void) | undefined;
+  const onRefresh = jest.fn((listener: () => void) => {
+    onRefreshListener = listener;
+    return { dispose };
+  });
+
+  const appConfig = { refresh, onRefresh } as unknown as Awaited<ReturnType<typeof load>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    onRefreshListener = undefined;
+    loadMock.mockResolvedValue(appConfig);
+    FeatureManagerMock.mockImplementation(() => ({ isEnabled, getVariant }));
+    ConfigurationMapFeatureFlagProviderMock.mockImplementation(() => ({ getFeatureFlag }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const createProvider = async (
+    config: AzureAppConfigurationProviderConfig = { connectionString: 'Endpoint=https://example;Id=abc;Secret=xyz' },
+  ) => {
+    const provider = new AzureAppConfigurationProvider(config);
+    await provider.initialize();
+    return provider;
+  };
+
+  it('should be an instance of AzureAppConfigurationProvider', () => {
+    expect(new AzureAppConfigurationProvider({ connectionString: 'cs' })).toBeInstanceOf(AzureAppConfigurationProvider);
+  });
+
+  it('exposes server metadata', () => {
+    const provider = new AzureAppConfigurationProvider({ connectionString: 'cs' });
+    expect(provider.metadata.name).toBe('azure-app-configuration-provider');
+    expect(provider.runsOn).toBe('server');
+  });
+
+  describe('initialize', () => {
+    it('loads feature flags using a connection string', async () => {
+      await createProvider({ connectionString: 'my-connection-string' });
+
+      expect(loadMock).toHaveBeenCalledWith('my-connection-string', {
+        featureFlagOptions: {
+          enabled: true,
+          selectors: [{ keyFilter: '*' }],
+          refresh: { enabled: true, refreshIntervalInMs: 30_000 },
+        },
+      });
+      expect(ConfigurationMapFeatureFlagProviderMock).toHaveBeenCalledWith(appConfig);
+      expect(FeatureManagerMock).toHaveBeenCalled();
+    });
+
+    it('loads feature flags using an endpoint and credential', async () => {
+      const credential = { getToken: jest.fn() };
+      const provider = new AzureAppConfigurationProvider({
+        endpoint: 'https://example.azconfig.io',
+        credential,
+        selectors: [{ keyFilter: 'app*', labelFilter: 'prod' }],
+        refreshIntervalInMs: 10_000,
+      });
+      await provider.initialize();
+
+      expect(loadMock).toHaveBeenCalledWith('https://example.azconfig.io', credential, {
+        featureFlagOptions: {
+          enabled: true,
+          selectors: [{ keyFilter: 'app*', labelFilter: 'prod' }],
+          refresh: { enabled: true, refreshIntervalInMs: 10_000 },
+        },
+      });
+    });
+
+    it('does not register a refresh timer or listener when refresh is disabled', async () => {
+      await createProvider({ connectionString: 'cs', enableRefresh: false });
+      expect(onRefresh).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(60_000);
+      expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it('throws a fatal error when load fails', async () => {
+      loadMock.mockRejectedValueOnce(new Error('bad credentials'));
+      const provider = new AzureAppConfigurationProvider({ connectionString: 'cs' });
+      await expect(provider.initialize()).rejects.toThrow('Failed to initialize Azure App Configuration provider');
+    });
+  });
+
+  describe('refresh and events', () => {
+    it('emits ConfigurationChanged when a refresh reports a change', async () => {
+      const provider = await createProvider();
+      const handler = jest.fn();
+      provider.events.addHandler(ProviderEvents.ConfigurationChanged, handler);
+
+      onRefreshListener?.();
+
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it('polls refresh on the configured interval', async () => {
+      await createProvider({ connectionString: 'cs', refreshIntervalInMs: 5_000 });
+
+      jest.advanceTimersByTime(12_000);
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('resolveBooleanEvaluation', () => {
+    it('returns the enabled state from the feature manager with a static reason when no filters apply', async () => {
+      const provider = await createProvider();
+      isEnabled.mockResolvedValue(true);
+      getFeatureFlag.mockResolvedValueOnce({ id: 'Beta', enabled: true });
+
+      const result = await provider.resolveBooleanEvaluation('Beta', false, { targetingKey: 'user-1' });
+
+      expect(isEnabled).toHaveBeenCalledWith('Beta', { userId: 'user-1', groups: undefined });
+      expect(result).toEqual({ value: true, reason: StandardResolutionReasons.STATIC });
+    });
+
+    it('returns TARGETING_MATCH when a targeting filter is configured', async () => {
+      const provider = await createProvider();
+      isEnabled.mockResolvedValue(true);
+      getFeatureFlag.mockResolvedValueOnce({
+        id: 'Beta',
+        enabled: true,
+        conditions: { client_filters: [{ name: 'Microsoft.Targeting' }] },
+      });
+
+      const result = await provider.resolveBooleanEvaluation('Beta', false, { targetingKey: 'user-1' });
+
+      expect(result).toEqual({ value: true, reason: StandardResolutionReasons.TARGETING_MATCH });
+    });
+
+    it('returns STATIC when the flag is disabled without evaluating filters', async () => {
+      const provider = await createProvider();
+      isEnabled.mockResolvedValue(false);
+      getFeatureFlag.mockResolvedValueOnce({
+        id: 'Beta',
+        enabled: false,
+        conditions: { client_filters: [{ name: 'Microsoft.Targeting' }] },
+      });
+
+      const result = await provider.resolveBooleanEvaluation('Beta', true, { targetingKey: 'user-1' });
+
+      expect(result).toEqual({ value: false, reason: StandardResolutionReasons.STATIC });
+    });
+
+    it('maps targetingKey and groups into the targeting context', async () => {
+      const provider = await createProvider();
+      isEnabled.mockResolvedValue(false);
+
+      await provider.resolveBooleanEvaluation('Beta', true, { targetingKey: 'user-2', groups: ['g1', 'g2'] });
+
+      expect(isEnabled).toHaveBeenCalledWith('Beta', { userId: 'user-2', groups: ['g1', 'g2'] });
+    });
+
+    it('throws ProviderNotReadyError when not initialized', async () => {
+      const provider = new AzureAppConfigurationProvider({ connectionString: 'cs' });
+      await expect(provider.resolveBooleanEvaluation('Beta', false, {})).rejects.toThrow(ProviderNotReadyError);
+    });
+
+    it('returns FLAG_NOT_FOUND when the flag is not found', async () => {
+      const provider = await createProvider();
+      getFeatureFlag.mockResolvedValueOnce(undefined);
+
+      const result = await provider.resolveBooleanEvaluation('MissingFlag', true, {});
+
+      expect(result).toEqual({
+        value: true,
+        reason: StandardResolutionReasons.ERROR,
+        errorCode: ErrorCode.FLAG_NOT_FOUND,
+        errorMessage: "Flag 'MissingFlag' was not found.",
+      });
+      expect(isEnabled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('variant-based evaluations', () => {
+    it('resolves a string variant configuration with DEFAULT when the default variant is assigned', async () => {
+      const provider = await createProvider();
+      isEnabled.mockResolvedValue(true);
+      getFeatureFlag.mockResolvedValueOnce({
+        id: 'Greeting',
+        enabled: true,
+        variants: [{ name: 'Large' }],
+        allocation: { default_when_enabled: 'Large' },
+      });
+      getVariant.mockResolvedValue(variant('Large', 'big'));
+
+      const result = await provider.resolveStringEvaluation('Greeting', 'default', { targetingKey: 'user-1' });
+
+      expect(result).toEqual({ value: 'big', variant: 'Large', reason: StandardResolutionReasons.DEFAULT });
+    });
+
+    it('resolves a string variant configuration with TARGETING_MATCH when user allocation matches', async () => {
+      const provider = await createProvider();
+      isEnabled.mockResolvedValue(true);
+      getFeatureFlag.mockResolvedValueOnce({
+        id: 'Greeting',
+        enabled: true,
+        variants: [{ name: 'Large' }],
+        allocation: { user: [{ variant: 'Large', users: ['user-1'] }] },
+      });
+      getVariant.mockResolvedValue(variant('Large', 'big'));
+
+      const result = await provider.resolveStringEvaluation('Greeting', 'default', { targetingKey: 'user-1' });
+
+      expect(result).toEqual({ value: 'big', variant: 'Large', reason: StandardResolutionReasons.TARGETING_MATCH });
+    });
+
+    it('resolves a number variant configuration with DEFAULT for the default variant', async () => {
+      const provider = await createProvider();
+      isEnabled.mockResolvedValue(true);
+      getFeatureFlag.mockResolvedValueOnce({
+        id: 'Price',
+        enabled: true,
+        variants: [{ name: 'Discount' }],
+        allocation: { default_when_enabled: 'Discount' },
+      });
+      getVariant.mockResolvedValue(variant('Discount', 42));
+
+      const result = await provider.resolveNumberEvaluation('Price', 0, {});
+
+      expect(result).toEqual({ value: 42, variant: 'Discount', reason: StandardResolutionReasons.DEFAULT });
+    });
+
+    it('resolves an object variant configuration with DEFAULT for the default variant', async () => {
+      const provider = await createProvider();
+      const config = { color: 'red', size: 10 };
+      isEnabled.mockResolvedValue(true);
+      getFeatureFlag.mockResolvedValueOnce({
+        id: 'Theme',
+        enabled: true,
+        variants: [{ name: 'Theme' }],
+        allocation: { default_when_enabled: 'Theme' },
+      });
+      getVariant.mockResolvedValue(variant('Theme', config));
+
+      const result = await provider.resolveObjectEvaluation('Theme', {}, {});
+
+      expect(result).toEqual({ value: config, variant: 'Theme', reason: StandardResolutionReasons.DEFAULT });
+    });
+
+    it('returns FLAG_NOT_FOUND when no variant is assigned', async () => {
+      const provider = await createProvider();
+      getVariant.mockResolvedValue(undefined);
+
+      const result = await provider.resolveStringEvaluation('Greeting', 'fallback', {});
+
+      expect(result).toEqual({
+        value: 'fallback',
+        reason: StandardResolutionReasons.ERROR,
+        errorCode: ErrorCode.FLAG_NOT_FOUND,
+        errorMessage: "Flag 'Greeting' was not found.",
+      });
+    });
+
+    it('returns FLAG_NOT_FOUND when the variant has no configuration', async () => {
+      const provider = await createProvider();
+      getVariant.mockResolvedValue(variant('Empty', undefined));
+
+      const result = await provider.resolveNumberEvaluation('Price', 7, {});
+
+      expect(result).toEqual({
+        value: 7,
+        reason: StandardResolutionReasons.ERROR,
+        errorCode: ErrorCode.FLAG_NOT_FOUND,
+        errorMessage: "Flag 'Price' was not found.",
+      });
+    });
+
+    it('throws TypeMismatchError when the variant type does not match', async () => {
+      const provider = await createProvider();
+      getVariant.mockResolvedValue(variant('Large', 'not-a-number'));
+
+      await expect(provider.resolveNumberEvaluation('Price', 0, {})).rejects.toThrow(TypeMismatchError);
+    });
+  });
+
+  describe('onClose', () => {
+    it('clears the timer and disposes the refresh listener', async () => {
+      const provider = await createProvider();
+
+      await provider.onClose();
+
+      expect(dispose).toHaveBeenCalled();
+
+      refresh.mockClear();
+      jest.advanceTimersByTime(60_000);
+      expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it('is safe to call before initialization', async () => {
+      const provider = new AzureAppConfigurationProvider({ connectionString: 'cs' });
+      await expect(provider.onClose()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.ts
+++ b/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.ts
@@ -1,0 +1,210 @@
+import type { EvaluationContext, JsonValue, Paradigm, Provider, ResolutionDetails } from '@openfeature/server-sdk';
+import {
+  ErrorCode,
+  OpenFeatureEventEmitter,
+  ProviderEvents,
+  ProviderFatalError,
+  ProviderNotReadyError,
+  StandardResolutionReasons,
+  TypeMismatchError,
+} from '@openfeature/server-sdk';
+import type { AzureAppConfiguration, Disposable, FeatureFlagOptions } from '@azure/app-configuration-provider';
+import { KeyFilter, load } from '@azure/app-configuration-provider';
+import { ConfigurationMapFeatureFlagProvider, FeatureManager } from '@microsoft/feature-management';
+import type { AzureAppConfigurationProviderConfig } from './types';
+import { transformContext } from './context-transformer';
+import { resolveBooleanResolutionReason, resolveVariantResolutionReason } from './resolution-reason';
+
+const DEFAULT_REFRESH_INTERVAL_MS = 30_000;
+
+export class AzureAppConfigurationProvider implements Provider {
+  public readonly runsOn: Paradigm = 'server';
+
+  public readonly events = new OpenFeatureEventEmitter();
+
+  public readonly metadata = {
+    name: 'azure-app-configuration-provider',
+  } as const;
+
+  public readonly hooks = [];
+
+  private readonly _config: AzureAppConfigurationProviderConfig;
+  private _appConfig?: AzureAppConfiguration;
+  private _featureFlagProvider?: ConfigurationMapFeatureFlagProvider;
+  private _featureManager?: FeatureManager;
+  private _refreshDisposable?: Disposable;
+  private _refreshTimer?: ReturnType<typeof setInterval>;
+
+  constructor(config: AzureAppConfigurationProviderConfig) {
+    this._config = config;
+  }
+
+  public async initialize(): Promise<void> {
+    const enableRefresh = this._config.enableRefresh ?? true;
+    const refreshIntervalInMs = this._config.refreshIntervalInMs ?? DEFAULT_REFRESH_INTERVAL_MS;
+    const selectors = this._config.selectors ?? [{ keyFilter: KeyFilter.Any }];
+
+    const featureFlagOptions: FeatureFlagOptions = {
+      enabled: true,
+      selectors,
+      refresh: {
+        enabled: enableRefresh,
+        refreshIntervalInMs,
+      },
+    };
+
+    try {
+      if ('connectionString' in this._config) {
+        this._appConfig = await load(this._config.connectionString, { featureFlagOptions });
+      } else {
+        this._appConfig = await load(this._config.endpoint, this._config.credential, { featureFlagOptions });
+      }
+    } catch (err) {
+      throw new ProviderFatalError(
+        `Failed to initialize Azure App Configuration provider: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    this._featureFlagProvider = new ConfigurationMapFeatureFlagProvider(this._appConfig);
+    this._featureManager = new FeatureManager(this._featureFlagProvider);
+
+    if (enableRefresh) {
+      this._refreshDisposable = this._appConfig.onRefresh(() => {
+        this.events.emit(ProviderEvents.ConfigurationChanged);
+      });
+
+      this._refreshTimer = setInterval(() => {
+        // Refresh is a no-op until the configured interval elapses, and any error is
+        // swallowed so that transient failures don't crash the host application; the
+        // provider keeps serving the last known good configuration.
+        void this._appConfig?.refresh().catch(() => undefined);
+      }, refreshIntervalInMs);
+
+      // Don't keep the event loop alive because of the refresh timer.
+      this._refreshTimer.unref?.();
+    }
+  }
+
+  public async onClose(): Promise<void> {
+    if (this._refreshTimer) {
+      clearInterval(this._refreshTimer);
+      this._refreshTimer = undefined;
+    }
+
+    this._refreshDisposable?.dispose();
+    this._refreshDisposable = undefined;
+    this._featureManager = undefined;
+    this._featureFlagProvider = undefined;
+    this._appConfig = undefined;
+  }
+
+  public async resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<boolean>> {
+    const featureManager = this.getFeatureManager();
+    const targetingContext = transformContext(context);
+
+    const featureFlag = await this._featureFlagProvider?.getFeatureFlag(flagKey);
+    if (!featureFlag) {
+      return {
+        value: defaultValue,
+        reason: StandardResolutionReasons.ERROR,
+        errorCode: ErrorCode.FLAG_NOT_FOUND,
+        errorMessage: `Flag '${flagKey}' was not found.`,
+      };
+    }
+
+    const value = await featureManager.isEnabled(flagKey, targetingContext);
+
+    return {
+      value,
+      reason: resolveBooleanResolutionReason(featureFlag),
+    };
+  }
+
+  public async resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<string>> {
+    return this.resolveVariant(flagKey, 'string', defaultValue, context);
+  }
+
+  public async resolveNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<number>> {
+    return this.resolveVariant(flagKey, 'number', defaultValue, context);
+  }
+
+  public async resolveObjectEvaluation<U extends JsonValue>(
+    flagKey: string,
+    defaultValue: U,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<U>> {
+    return this.resolveVariant(flagKey, 'object', defaultValue, context);
+  }
+
+  private async resolveVariant<T extends JsonValue>(
+    flagKey: string,
+    type: 'string' | 'number' | 'object',
+    defaultValue: T,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<T>> {
+    const featureManager = this.getFeatureManager();
+    const targetingContext = transformContext(context);
+
+    const featureFlag = await this._featureFlagProvider?.getFeatureFlag(flagKey);
+    if (!featureFlag) {
+      return {
+        value: defaultValue,
+        reason: StandardResolutionReasons.ERROR,
+        errorCode: ErrorCode.FLAG_NOT_FOUND,
+        errorMessage: `Flag '${flagKey}' was not found.`,
+      };
+    }
+
+    const enabled = await featureManager.isEnabled(flagKey, targetingContext);
+    const variant = await featureManager.getVariant(flagKey, targetingContext);
+
+    if (!variant || variant.configuration === undefined || variant.configuration === null) {
+      return {
+        value: defaultValue,
+        reason: StandardResolutionReasons.ERROR,
+        errorCode: ErrorCode.FLAG_NOT_FOUND,
+        errorMessage: `Flag '${flagKey}' was not found.`,
+      };
+    }
+
+    const value = variant.configuration;
+
+    if (type === 'string' && typeof value !== 'string') {
+      throw new TypeMismatchError(`Variant configuration for flag "${flagKey}" is not a string`);
+    }
+
+    if (type === 'number' && typeof value !== 'number') {
+      throw new TypeMismatchError(`Variant configuration for flag "${flagKey}" is not a number`);
+    }
+
+    if (type === 'object' && (typeof value !== 'object' || value === null)) {
+      throw new TypeMismatchError(`Variant configuration for flag "${flagKey}" is not an object`);
+    }
+
+    return {
+      value: value as T,
+      variant: variant.name,
+      reason: await resolveVariantResolutionReason(featureFlag, targetingContext, enabled),
+    };
+  }
+
+  private getFeatureManager(): FeatureManager {
+    if (!this._featureManager) {
+      throw new ProviderNotReadyError('Azure App Configuration provider is not initialized');
+    }
+
+    return this._featureManager;
+  }
+}

--- a/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.ts
+++ b/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.ts
@@ -167,15 +167,15 @@ export class AzureAppConfigurationProvider implements Provider {
       };
     }
 
-    const enabled = await featureManager.isEnabled(flagKey, targetingContext);
-    const variant = await featureManager.getVariant(flagKey, targetingContext);
+    const [enabled, variant] = await Promise.all([
+      featureManager.isEnabled(flagKey, targetingContext),
+      featureManager.getVariant(flagKey, targetingContext),
+    ]);
 
     if (!variant || variant.configuration === undefined || variant.configuration === null) {
       return {
         value: defaultValue,
-        reason: StandardResolutionReasons.ERROR,
-        errorCode: ErrorCode.FLAG_NOT_FOUND,
-        errorMessage: `Flag '${flagKey}' was not found.`,
+        reason: StandardResolutionReasons.DEFAULT,
       };
     }
 

--- a/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.ts
+++ b/libs/providers/azure-app-configuration/src/lib/azure-app-configuration-provider.ts
@@ -196,7 +196,7 @@ export class AzureAppConfigurationProvider implements Provider {
     return {
       value: value as T,
       variant: variant.name,
-      reason: await resolveVariantResolutionReason(featureFlag, targetingContext, enabled),
+      reason: resolveVariantResolutionReason(featureFlag, variant.name, enabled),
     };
   }
 

--- a/libs/providers/azure-app-configuration/src/lib/context-transformer.ts
+++ b/libs/providers/azure-app-configuration/src/lib/context-transformer.ts
@@ -1,0 +1,18 @@
+import type { EvaluationContext } from '@openfeature/server-sdk';
+import type { ITargetingContext } from '@microsoft/feature-management';
+
+/**
+ * Maps an OpenFeature {@link EvaluationContext} to the Azure feature-management
+ * {@link ITargetingContext}.
+ *
+ * - `targetingKey` maps to `userId`.
+ * - a `groups` attribute (array of strings) maps to `groups`.
+ */
+export function transformContext(context: EvaluationContext): ITargetingContext {
+  const groups = context['groups'];
+
+  return {
+    userId: context.targetingKey,
+    groups: Array.isArray(groups) ? groups.filter((group): group is string => typeof group === 'string') : undefined,
+  };
+}

--- a/libs/providers/azure-app-configuration/src/lib/resolution-reason.spec.ts
+++ b/libs/providers/azure-app-configuration/src/lib/resolution-reason.spec.ts
@@ -1,0 +1,96 @@
+import { StandardResolutionReasons } from '@openfeature/server-sdk';
+import { resolveBooleanResolutionReason, resolveVariantResolutionReason } from './resolution-reason';
+
+describe('resolution-reason', () => {
+  describe('resolveBooleanResolutionReason', () => {
+    it('returns STATIC for a flag that is not explicitly enabled', () => {
+      expect(resolveBooleanResolutionReason({ id: 'flag', enabled: false })).toBe(StandardResolutionReasons.STATIC);
+    });
+
+    it('returns STATIC for an enabled flag without client filters', () => {
+      expect(resolveBooleanResolutionReason({ id: 'flag', enabled: true })).toBe(StandardResolutionReasons.STATIC);
+    });
+
+    it('returns STATIC for an enabled flag with only non-targeting filters', () => {
+      expect(
+        resolveBooleanResolutionReason({
+          id: 'flag',
+          enabled: true,
+          conditions: { client_filters: [{ name: 'Microsoft.TimeWindow' }] },
+        }),
+      ).toBe(StandardResolutionReasons.STATIC);
+    });
+
+    it('returns TARGETING_MATCH when a targeting filter is configured', () => {
+      expect(
+        resolveBooleanResolutionReason({
+          id: 'flag',
+          enabled: true,
+          conditions: { client_filters: [{ name: 'Microsoft.Targeting' }] },
+        }),
+      ).toBe(StandardResolutionReasons.TARGETING_MATCH);
+    });
+  });
+
+  describe('resolveVariantResolutionReason', () => {
+    it('returns DEFAULT for the default variant when the flag is enabled', async () => {
+      await expect(
+        resolveVariantResolutionReason(
+          {
+            id: 'flag',
+            enabled: true,
+            variants: [{ name: 'Large' }],
+            allocation: { default_when_enabled: 'Large' },
+          },
+          { userId: 'user-1' },
+          true,
+        ),
+      ).resolves.toBe(StandardResolutionReasons.DEFAULT);
+    });
+
+    it('returns DEFAULT for the default variant when the flag is disabled', async () => {
+      await expect(
+        resolveVariantResolutionReason(
+          {
+            id: 'flag',
+            enabled: false,
+            variants: [{ name: 'Small' }],
+            allocation: { default_when_disabled: 'Small' },
+          },
+          { userId: 'user-1' },
+          false,
+        ),
+      ).resolves.toBe(StandardResolutionReasons.DEFAULT);
+    });
+
+    it('returns TARGETING_MATCH when user allocation matches', async () => {
+      await expect(
+        resolveVariantResolutionReason(
+          {
+            id: 'flag',
+            enabled: true,
+            variants: [{ name: 'Large' }],
+            allocation: { user: [{ variant: 'Large', users: ['user-1'] }] },
+          },
+          { userId: 'user-1' },
+          true,
+        ),
+      ).resolves.toBe(StandardResolutionReasons.TARGETING_MATCH);
+    });
+
+    it('returns TARGETING_MATCH when group allocation matches', async () => {
+      await expect(
+        resolveVariantResolutionReason(
+          {
+            id: 'flag',
+            enabled: true,
+            variants: [{ name: 'Large' }],
+            allocation: { group: [{ variant: 'Large', groups: ['beta'] }] },
+          },
+          { userId: 'user-1', groups: ['beta'] },
+          true,
+        ),
+      ).resolves.toBe(StandardResolutionReasons.TARGETING_MATCH);
+    });
+  });
+});

--- a/libs/providers/azure-app-configuration/src/lib/resolution-reason.spec.ts
+++ b/libs/providers/azure-app-configuration/src/lib/resolution-reason.spec.ts
@@ -33,8 +33,8 @@ describe('resolution-reason', () => {
   });
 
   describe('resolveVariantResolutionReason', () => {
-    it('returns DEFAULT for the default variant when the flag is enabled', async () => {
-      await expect(
+    it('returns DEFAULT for the default variant when the flag is enabled', () => {
+      expect(
         resolveVariantResolutionReason(
           {
             id: 'flag',
@@ -42,14 +42,14 @@ describe('resolution-reason', () => {
             variants: [{ name: 'Large' }],
             allocation: { default_when_enabled: 'Large' },
           },
-          { userId: 'user-1' },
+          'Large',
           true,
         ),
-      ).resolves.toBe(StandardResolutionReasons.DEFAULT);
+      ).toBe(StandardResolutionReasons.DEFAULT);
     });
 
-    it('returns DEFAULT for the default variant when the flag is disabled', async () => {
-      await expect(
+    it('returns DEFAULT for the default variant when the flag is disabled', () => {
+      expect(
         resolveVariantResolutionReason(
           {
             id: 'flag',
@@ -57,40 +57,69 @@ describe('resolution-reason', () => {
             variants: [{ name: 'Small' }],
             allocation: { default_when_disabled: 'Small' },
           },
-          { userId: 'user-1' },
+          'Small',
           false,
         ),
-      ).resolves.toBe(StandardResolutionReasons.DEFAULT);
+      ).toBe(StandardResolutionReasons.DEFAULT);
     });
 
-    it('returns TARGETING_MATCH when user allocation matches', async () => {
-      await expect(
+    it('returns DEFAULT when status_override disables the default_when_enabled variant', () => {
+      expect(
+        resolveVariantResolutionReason(
+          {
+            id: 'flag',
+            enabled: true,
+            variants: [{ name: 'Off' }],
+            allocation: { default_when_enabled: 'Off' },
+          },
+          'Off',
+          false,
+        ),
+      ).toBe(StandardResolutionReasons.DEFAULT);
+    });
+
+    it('returns TARGETING_MATCH when status_override disables a targeted variant', () => {
+      expect(
+        resolveVariantResolutionReason(
+          {
+            id: 'flag',
+            enabled: true,
+            variants: [{ name: 'On' }],
+            allocation: { default_when_enabled: 'Off' },
+          },
+          'On',
+          false,
+        ),
+      ).toBe(StandardResolutionReasons.TARGETING_MATCH);
+    });
+
+    it('returns TARGETING_MATCH when an enabled flag assigns a non-default variant', () => {
+      expect(
         resolveVariantResolutionReason(
           {
             id: 'flag',
             enabled: true,
             variants: [{ name: 'Large' }],
-            allocation: { user: [{ variant: 'Large', users: ['user-1'] }] },
+            allocation: { default_when_enabled: 'Small' },
           },
-          { userId: 'user-1' },
+          'Large',
           true,
         ),
-      ).resolves.toBe(StandardResolutionReasons.TARGETING_MATCH);
+      ).toBe(StandardResolutionReasons.TARGETING_MATCH);
     });
 
-    it('returns TARGETING_MATCH when group allocation matches', async () => {
-      await expect(
+    it('returns TARGETING_MATCH when an enabled flag assigns a variant without a configured default', () => {
+      expect(
         resolveVariantResolutionReason(
           {
             id: 'flag',
             enabled: true,
             variants: [{ name: 'Large' }],
-            allocation: { group: [{ variant: 'Large', groups: ['beta'] }] },
           },
-          { userId: 'user-1', groups: ['beta'] },
+          'Large',
           true,
         ),
-      ).resolves.toBe(StandardResolutionReasons.TARGETING_MATCH);
+      ).toBe(StandardResolutionReasons.TARGETING_MATCH);
     });
   });
 });

--- a/libs/providers/azure-app-configuration/src/lib/resolution-reason.ts
+++ b/libs/providers/azure-app-configuration/src/lib/resolution-reason.ts
@@ -1,8 +1,5 @@
-import type { ITargetingContext } from '@microsoft/feature-management';
-import { VariantAssignmentReason } from '@microsoft/feature-management';
 import type { ResolutionReason } from '@openfeature/server-sdk';
 import { StandardResolutionReasons } from '@openfeature/server-sdk';
-import { createHash } from 'node:crypto';
 
 const TARGETING_FILTER = 'Microsoft.Targeting';
 
@@ -15,14 +12,14 @@ export interface FeatureFlagDefinition {
   allocation?: {
     default_when_disabled?: string;
     default_when_enabled?: string;
-    user?: { variant: string; users: string[] }[];
-    group?: { variant: string; groups: string[] }[];
-    percentile?: { variant: string; from: number; to: number }[];
-    seed?: string;
   };
   variants?: { name: string }[];
 }
 
+// OpenFeature resolution reasons are optional telemetry, so these helpers derive a
+// best-effort reason from the flag definition and the variant the underlying
+// library actually assigned. We deliberately avoid re-deriving
+// @microsoft/feature-management's targeting/bucketing logic to prevent drift.
 export function resolveBooleanResolutionReason(featureFlag: FeatureFlagDefinition): ResolutionReason {
   if (featureFlag.enabled !== true) {
     return StandardResolutionReasons.STATIC;
@@ -37,109 +34,32 @@ export function resolveBooleanResolutionReason(featureFlag: FeatureFlagDefinitio
   return appliesTargeting ? StandardResolutionReasons.TARGETING_MATCH : StandardResolutionReasons.STATIC;
 }
 
-export async function resolveVariantResolutionReason(
+export function resolveVariantResolutionReason(
   featureFlag: FeatureFlagDefinition,
-  targetingContext: ITargetingContext,
+  assignedVariantName: string,
   enabled: boolean,
-): Promise<ResolutionReason> {
-  if (!featureFlag.variants?.length) {
-    return StandardResolutionReasons.STATIC;
-  }
-
-  let assignmentReason = VariantAssignmentReason.None;
+): ResolutionReason {
+  const allocation = featureFlag.allocation;
 
   if (!enabled) {
-    assignmentReason = VariantAssignmentReason.DefaultWhenDisabled;
-  } else if (featureFlag.allocation) {
-    const targetedReason = await resolveTargetingAllocationReason(featureFlag, targetingContext);
-    assignmentReason =
-      targetedReason !== VariantAssignmentReason.None ? targetedReason : VariantAssignmentReason.DefaultWhenEnabled;
-  } else {
-    assignmentReason = VariantAssignmentReason.DefaultWhenEnabled;
-  }
-
-  return mapVariantAssignmentReason(assignmentReason);
-}
-
-function mapVariantAssignmentReason(reason: VariantAssignmentReason): ResolutionReason {
-  switch (reason) {
-    case VariantAssignmentReason.User:
-    case VariantAssignmentReason.Group:
-    case VariantAssignmentReason.Percentile:
-      return StandardResolutionReasons.TARGETING_MATCH;
-    case VariantAssignmentReason.DefaultWhenDisabled:
-    case VariantAssignmentReason.DefaultWhenEnabled:
+    // Kill-switch: flag disabled in configuration resolves via default_when_disabled.
+    if (featureFlag.enabled !== true) {
       return StandardResolutionReasons.DEFAULT;
-    default:
+    }
+
+    // Flag remains enabled in config; isEnabled=false comes from status_override on the assigned variant.
+    if (allocation?.default_when_enabled !== undefined && assignedVariantName === allocation.default_when_enabled) {
       return StandardResolutionReasons.DEFAULT;
-  }
-}
-
-async function resolveTargetingAllocationReason(
-  featureFlag: FeatureFlagDefinition,
-  targetingContext: ITargetingContext,
-): Promise<VariantAssignmentReason> {
-  const allocation = featureFlag.allocation;
-  if (!allocation) {
-    return VariantAssignmentReason.None;
-  }
-
-  if (allocation.user) {
-    for (const userAllocation of allocation.user) {
-      if (isTargetedUser(targetingContext.userId, userAllocation.users)) {
-        return VariantAssignmentReason.User;
-      }
     }
+
+    return StandardResolutionReasons.TARGETING_MATCH;
   }
 
-  if (allocation.group) {
-    for (const groupAllocation of allocation.group) {
-      if (isTargetedGroup(targetingContext.groups, groupAllocation.groups)) {
-        return VariantAssignmentReason.Group;
-      }
-    }
+  // Enabled and the assigned variant is the configured default => DEFAULT.
+  if (allocation?.default_when_enabled !== undefined && assignedVariantName === allocation.default_when_enabled) {
+    return StandardResolutionReasons.DEFAULT;
   }
 
-  if (allocation.percentile) {
-    for (const percentileAllocation of allocation.percentile) {
-      const hint = allocation.seed ?? `allocation\n${featureFlag.id}`;
-      if (isTargetedPercentile(targetingContext.userId, hint, percentileAllocation.from, percentileAllocation.to)) {
-        return VariantAssignmentReason.Percentile;
-      }
-    }
-  }
-
-  return VariantAssignmentReason.None;
-}
-
-function isTargetedUser(userId: string | undefined, users: string[]): boolean {
-  if (userId === undefined) {
-    return false;
-  }
-
-  return users.includes(userId);
-}
-
-function isTargetedGroup(sourceGroups: string[] | undefined, targetedGroups: string[]): boolean {
-  if (sourceGroups === undefined) {
-    return false;
-  }
-
-  return sourceGroups.some((group) => targetedGroups.includes(group));
-}
-
-function isTargetedPercentile(userId: string | undefined, hint: string, from: number, to: number): boolean {
-  if (from < 0 || from > 100 || to < 0 || to > 100 || from > to) {
-    return false;
-  }
-
-  const audienceContextId = `${userId ?? ''}\n${hint}`;
-  const contextMarker = createHash('sha256').update(audienceContextId).digest().readUInt32LE(0);
-  const contextPercentage = (contextMarker / 0xffffffff) * 100;
-
-  if (to === 100) {
-    return contextPercentage >= from;
-  }
-
-  return contextPercentage >= from && contextPercentage < to;
+  // Otherwise the library assigned the variant through a user/group/percentile allocation.
+  return StandardResolutionReasons.TARGETING_MATCH;
 }

--- a/libs/providers/azure-app-configuration/src/lib/resolution-reason.ts
+++ b/libs/providers/azure-app-configuration/src/lib/resolution-reason.ts
@@ -1,0 +1,145 @@
+import type { ITargetingContext } from '@microsoft/feature-management';
+import { VariantAssignmentReason } from '@microsoft/feature-management';
+import type { ResolutionReason } from '@openfeature/server-sdk';
+import { StandardResolutionReasons } from '@openfeature/server-sdk';
+import { createHash } from 'node:crypto';
+
+const TARGETING_FILTER = 'Microsoft.Targeting';
+
+export interface FeatureFlagDefinition {
+  id: string;
+  enabled?: boolean;
+  conditions?: {
+    client_filters?: { name: string }[];
+  };
+  allocation?: {
+    default_when_disabled?: string;
+    default_when_enabled?: string;
+    user?: { variant: string; users: string[] }[];
+    group?: { variant: string; groups: string[] }[];
+    percentile?: { variant: string; from: number; to: number }[];
+    seed?: string;
+  };
+  variants?: { name: string }[];
+}
+
+export function resolveBooleanResolutionReason(featureFlag: FeatureFlagDefinition): ResolutionReason {
+  if (featureFlag.enabled !== true) {
+    return StandardResolutionReasons.STATIC;
+  }
+
+  const clientFilters = featureFlag.conditions?.client_filters;
+  if (!clientFilters?.length) {
+    return StandardResolutionReasons.STATIC;
+  }
+
+  const appliesTargeting = clientFilters.some((filter) => filter.name === TARGETING_FILTER);
+  return appliesTargeting ? StandardResolutionReasons.TARGETING_MATCH : StandardResolutionReasons.STATIC;
+}
+
+export async function resolveVariantResolutionReason(
+  featureFlag: FeatureFlagDefinition,
+  targetingContext: ITargetingContext,
+  enabled: boolean,
+): Promise<ResolutionReason> {
+  if (!featureFlag.variants?.length) {
+    return StandardResolutionReasons.STATIC;
+  }
+
+  let assignmentReason = VariantAssignmentReason.None;
+
+  if (!enabled) {
+    assignmentReason = VariantAssignmentReason.DefaultWhenDisabled;
+  } else if (featureFlag.allocation) {
+    const targetedReason = await resolveTargetingAllocationReason(featureFlag, targetingContext);
+    assignmentReason =
+      targetedReason !== VariantAssignmentReason.None ? targetedReason : VariantAssignmentReason.DefaultWhenEnabled;
+  } else {
+    assignmentReason = VariantAssignmentReason.DefaultWhenEnabled;
+  }
+
+  return mapVariantAssignmentReason(assignmentReason);
+}
+
+function mapVariantAssignmentReason(reason: VariantAssignmentReason): ResolutionReason {
+  switch (reason) {
+    case VariantAssignmentReason.User:
+    case VariantAssignmentReason.Group:
+    case VariantAssignmentReason.Percentile:
+      return StandardResolutionReasons.TARGETING_MATCH;
+    case VariantAssignmentReason.DefaultWhenDisabled:
+    case VariantAssignmentReason.DefaultWhenEnabled:
+      return StandardResolutionReasons.DEFAULT;
+    default:
+      return StandardResolutionReasons.DEFAULT;
+  }
+}
+
+async function resolveTargetingAllocationReason(
+  featureFlag: FeatureFlagDefinition,
+  targetingContext: ITargetingContext,
+): Promise<VariantAssignmentReason> {
+  const allocation = featureFlag.allocation;
+  if (!allocation) {
+    return VariantAssignmentReason.None;
+  }
+
+  if (allocation.user) {
+    for (const userAllocation of allocation.user) {
+      if (isTargetedUser(targetingContext.userId, userAllocation.users)) {
+        return VariantAssignmentReason.User;
+      }
+    }
+  }
+
+  if (allocation.group) {
+    for (const groupAllocation of allocation.group) {
+      if (isTargetedGroup(targetingContext.groups, groupAllocation.groups)) {
+        return VariantAssignmentReason.Group;
+      }
+    }
+  }
+
+  if (allocation.percentile) {
+    for (const percentileAllocation of allocation.percentile) {
+      const hint = allocation.seed ?? `allocation\n${featureFlag.id}`;
+      if (isTargetedPercentile(targetingContext.userId, hint, percentileAllocation.from, percentileAllocation.to)) {
+        return VariantAssignmentReason.Percentile;
+      }
+    }
+  }
+
+  return VariantAssignmentReason.None;
+}
+
+function isTargetedUser(userId: string | undefined, users: string[]): boolean {
+  if (userId === undefined) {
+    return false;
+  }
+
+  return users.includes(userId);
+}
+
+function isTargetedGroup(sourceGroups: string[] | undefined, targetedGroups: string[]): boolean {
+  if (sourceGroups === undefined) {
+    return false;
+  }
+
+  return sourceGroups.some((group) => targetedGroups.includes(group));
+}
+
+function isTargetedPercentile(userId: string | undefined, hint: string, from: number, to: number): boolean {
+  if (from < 0 || from > 100 || to < 0 || to > 100 || from > to) {
+    return false;
+  }
+
+  const audienceContextId = `${userId ?? ''}\n${hint}`;
+  const contextMarker = createHash('sha256').update(audienceContextId).digest().readUInt32LE(0);
+  const contextPercentage = (contextMarker / 0xffffffff) * 100;
+
+  if (to === 100) {
+    return contextPercentage >= from;
+  }
+
+  return contextPercentage >= from && contextPercentage < to;
+}

--- a/libs/providers/azure-app-configuration/src/lib/types.ts
+++ b/libs/providers/azure-app-configuration/src/lib/types.ts
@@ -1,0 +1,60 @@
+import type { TokenCredential } from '@azure/identity';
+import type { SettingSelector } from '@azure/app-configuration-provider';
+
+/**
+ * Options shared by every way of configuring the provider.
+ */
+export interface AzureAppConfigurationCommonOptions {
+  /**
+   * Feature flag selectors used to filter which feature flags are loaded from the store.
+   * Defaults to a single selector matching all feature flags with no label (`[{ keyFilter: '*' }]`).
+   */
+  selectors?: SettingSelector[];
+
+  /**
+   * Whether the provider periodically refreshes feature flags from Azure App Configuration.
+   * When enabled, a `ProviderEvents.ConfigurationChanged` event is emitted whenever a refresh
+   * detects a change.
+   *
+   * @defaultValue true
+   */
+  enableRefresh?: boolean;
+
+  /**
+   * The interval, in milliseconds, at which the provider polls Azure App Configuration for
+   * changes when `enableRefresh` is `true`. Must be greater than 1000 (1 second).
+   *
+   * @defaultValue 30000
+   */
+  refreshIntervalInMs?: number;
+}
+
+/**
+ * Configure the provider using an Azure App Configuration connection string.
+ */
+export interface AzureAppConfigurationConnectionStringConfig extends AzureAppConfigurationCommonOptions {
+  /**
+   * The connection string for the Azure App Configuration store.
+   */
+  connectionString: string;
+}
+
+/**
+ * Configure the provider using an endpoint and a token credential (e.g. `DefaultAzureCredential`).
+ */
+export interface AzureAppConfigurationEndpointConfig extends AzureAppConfigurationCommonOptions {
+  /**
+   * The endpoint URL of the Azure App Configuration store.
+   */
+  endpoint: string;
+
+  /**
+   * The token credential used to authenticate to the Azure App Configuration store.
+   * See {@link https://learn.microsoft.com/javascript/api/overview/azure/identity-readme}.
+   */
+  credential: TokenCredential;
+}
+
+export type AzureAppConfigurationProviderConfig =
+  | AzureAppConfigurationConnectionStringConfig
+  | AzureAppConfigurationEndpointConfig;

--- a/libs/providers/azure-app-configuration/tsconfig.json
+++ b/libs/providers/azure-app-configuration/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/providers/azure-app-configuration/tsconfig.lib.json
+++ b/libs/providers/azure-app-configuration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/providers/azure-app-configuration/tsconfig.spec.json
+++ b/libs/providers/azure-app-configuration/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "isolatedModules": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "jest.config.cts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/nx.json
+++ b/nx.json
@@ -45,5 +45,10 @@
   "useInferencePlugins": false,
   "defaultBase": "main",
   "neverConnectToCloud": true,
-  "analytics": false
+  "analytics": false,
+  "release": {
+    "version": {
+      "preVersionCommand": "npx nx run-many -t build"
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,11 @@
         "unleash-proxy-client": "^3.6.0"
       },
       "devDependencies": {
+        "@azure/app-configuration-provider": "^2.5.1",
+        "@azure/identity": "^4.13.1",
         "@bufbuild/buf": "^1.34.0",
         "@edge-runtime/jest-environment": "^4.0.0",
+        "@microsoft/feature-management": "^2.3.1",
         "@nx/devkit": "22.7.1",
         "@nx/eslint": "22.7.1",
         "@nx/eslint-plugin": "22.7.1",
@@ -84,6 +87,7 @@
         "jest": "30.0.5",
         "jest-cucumber": "^4.4.0",
         "jest-environment-jsdom": "30.0.5",
+        "jest-environment-node": "^30.0.2",
         "jest-fetch-mock": "^3.0.3",
         "jest-util": "30.0.5",
         "jest-websocket-mock": "^2.4.0",
@@ -786,6 +790,374 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure-rest/core-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.7.0.tgz",
+      "integrity": "sha512-rL0lJqh1E8HLXNgjIw8cRyGAV/v+m6p1xRu/8OhsnmN8XHhwkyYJkAoGM+zrew96v7jZYPmVfy7pv7v4Iccfsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.24.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/app-configuration": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration/-/app-configuration-1.12.1.tgz",
+      "integrity": "sha512-skUcJ8ca5X7RQU92svaGtpefp3ncI/LqFbc+IiQR0KCT//+TlwJN52nsloGsqwr8+b4fo+refWJp53iqqHEqbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.6.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^3.1.0",
+        "@azure/core-paging": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.6.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/app-configuration-provider": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration-provider/-/app-configuration-provider-2.5.1.tgz",
+      "integrity": "sha512-e7RXFmgZzlCKvwwpwKc5K8jqDTvNkUH6OiEPccvye5eQwQR/DvTPvY811EdbxzCRbKgZbUgWi72Hd5vmzSADfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/app-configuration": "^1.11.0",
+        "@azure/core-rest-pipeline": "^1.6.0",
+        "@azure/identity": "^4.2.1",
+        "@azure/keyvault-secrets": "^4.7.0",
+        "jsonc-parser": "^3.3.1"
+      }
+    },
+    "node_modules/@azure/app-configuration-provider/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-3.3.1.tgz",
+      "integrity": "sha512-bulm3klLqIAhzI3iQMYQ42i+V9EnevScsHdI9amFfjaw6OJqPBK1038cq5qachoKV3yt/iQQEDittHmZW2aSuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-secrets": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-secrets/-/keyvault-secrets-4.11.2.tgz",
+      "integrity": "sha512-ECj/kwZbZlQXj2kfWivSICbKwj6W3chmFhv8qUdauqYnjvZ0hWZBFSsZWux7W2nX3MP49PLUCusXk+hAg3pipg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.1.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-secrets/node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.16.0.tgz",
+      "integrity": "sha512-Wc75FGnQgYpsm5jsOqn1H8AXsh8vXruA6vwip1nhjrJxwby7juxKAIVLr7csepmHiwdZGr6EwI5BlSc3PizEtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.11.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.0.tgz",
+      "integrity": "sha512-UikJOtMwkFpZNzTH6Dqk8UTUPbow15zH3e0UjGYZy69lYENW/S05gMLhbxI2eonz66uALhIljvhsSMEb6+O30g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.1.tgz",
+      "integrity": "sha512-sqqv3L1UOI4KDXonNtbxPYUgbSWVXqxvmmb6BUw9n4P/UXgG+cVur3dLWQN4Cz7qQ+UJROCCxMXlksm7gIq0Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.11.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5797,6 +6169,13 @@
       "integrity": "sha512-ikD6MElNa3WPUxXdUIDSBvbig21gfjemEus1Vh0HGcgLThxGglq+EGb0coyc8199+3aqu8c9kpuXEdMBZhOowA==",
       "license": "Apache-2.0"
     },
+    "node_modules/@microsoft/feature-management": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/feature-management/-/feature-management-2.3.1.tgz",
+      "integrity": "sha512-ThisghFgbtzLvUr2ShV9aqLNn/hGopH9YfyeImjGGbYFkpH7HB31GMcmhK7rJvEJClR24szgw91y0K9XM2AWJA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.39.2",
       "dev": true,
@@ -9682,6 +10061,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "dev": true,
@@ -12078,6 +12472,22 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/byline": {
       "version": "5.0.0",
       "dev": true,
@@ -13036,6 +13446,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/defaults": {
@@ -15849,6 +16289,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -23352,6 +23827,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -25488,6 +25976,38 @@
         }
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -26206,6 +26726,284 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="
+    },
+    "@azure-rest/core-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.7.0.tgz",
+      "integrity": "sha512-rL0lJqh1E8HLXNgjIw8cRyGAV/v+m6p1xRu/8OhsnmN8XHhwkyYJkAoGM+zrew96v7jZYPmVfy7pv7v4Iccfsg==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.24.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/app-configuration": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration/-/app-configuration-1.12.1.tgz",
+      "integrity": "sha512-skUcJ8ca5X7RQU92svaGtpefp3ncI/LqFbc+IiQR0KCT//+TlwJN52nsloGsqwr8+b4fo+refWJp53iqqHEqbA==",
+      "dev": true,
+      "requires": {
+        "@azure-rest/core-client": "^2.6.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^3.1.0",
+        "@azure/core-paging": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.6.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@azure/app-configuration-provider": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration-provider/-/app-configuration-provider-2.5.1.tgz",
+      "integrity": "sha512-e7RXFmgZzlCKvwwpwKc5K8jqDTvNkUH6OiEPccvye5eQwQR/DvTPvY811EdbxzCRbKgZbUgWi72Hd5vmzSADfQ==",
+      "dev": true,
+      "requires": {
+        "@azure/app-configuration": "^1.11.0",
+        "@azure/core-rest-pipeline": "^1.6.0",
+        "@azure/identity": "^4.2.1",
+        "@azure/keyvault-secrets": "^4.7.0",
+        "jsonc-parser": "^3.3.1"
+      },
+      "dependencies": {
+        "jsonc-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+          "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+          "dev": true
+        }
+      }
+    },
+    "@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.1.2"
+      }
+    },
+    "@azure/core-lro": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-3.3.1.tgz",
+      "integrity": "sha512-bulm3klLqIAhzI3iQMYQ42i+V9EnevScsHdI9amFfjaw6OJqPBK1038cq5qachoKV3yt/iQQEDittHmZW2aSuA==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "define-lazy-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+          "dev": true
+        },
+        "open": {
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+          "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+          "dev": true,
+          "requires": {
+            "default-browser": "^5.2.1",
+            "define-lazy-prop": "^3.0.0",
+            "is-inside-container": "^1.0.0",
+            "wsl-utils": "^0.1.0"
+          }
+        }
+      }
+    },
+    "@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
+      "dev": true,
+      "requires": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@azure/keyvault-secrets": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-secrets/-/keyvault-secrets-4.11.2.tgz",
+      "integrity": "sha512-ECj/kwZbZlQXj2kfWivSICbKwj6W3chmFhv8qUdauqYnjvZ0hWZBFSsZWux7W2nX3MP49PLUCusXk+hAg3pipg==",
+      "dev": true,
+      "requires": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.1.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "dependencies": {
+        "@azure/core-lro": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+          "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+          "dev": true,
+          "requires": {
+            "@azure/abort-controller": "^2.0.0",
+            "@azure/core-util": "^1.2.0",
+            "@azure/logger": "^1.0.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dev": true,
+      "requires": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@azure/msal-browser": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.16.0.tgz",
+      "integrity": "sha512-Wc75FGnQgYpsm5jsOqn1H8AXsh8vXruA6vwip1nhjrJxwby7juxKAIVLr7csepmHiwdZGr6EwI5BlSc3PizEtQ==",
+      "dev": true,
+      "requires": {
+        "@azure/msal-common": "16.11.0"
+      }
+    },
+    "@azure/msal-common": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.0.tgz",
+      "integrity": "sha512-UikJOtMwkFpZNzTH6Dqk8UTUPbow15zH3e0UjGYZy69lYENW/S05gMLhbxI2eonz66uALhIljvhsSMEb6+O30g==",
+      "dev": true
+    },
+    "@azure/msal-node": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.1.tgz",
+      "integrity": "sha512-sqqv3L1UOI4KDXonNtbxPYUgbSWVXqxvmmb6BUw9n4P/UXgG+cVur3dLWQN4Cz7qQ+UJROCCxMXlksm7gIq0Sw==",
+      "dev": true,
+      "requires": {
+        "@azure/msal-common": "16.11.0",
+        "jsonwebtoken": "^9.0.0"
+      }
     },
     "@babel/code-frame": {
       "version": "7.29.0",
@@ -29528,6 +30326,12 @@
       "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.4.tgz",
       "integrity": "sha512-ikD6MElNa3WPUxXdUIDSBvbig21gfjemEus1Vh0HGcgLThxGglq+EGb0coyc8199+3aqu8c9kpuXEdMBZhOowA=="
     },
+    "@microsoft/feature-management": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/feature-management/-/feature-management-2.3.1.tgz",
+      "integrity": "sha512-ThisghFgbtzLvUr2ShV9aqLNn/hGopH9YfyeImjGGbYFkpH7HB31GMcmhK7rJvEJClR24szgw91y0K9XM2AWJA==",
+      "dev": true
+    },
     "@mswjs/interceptors": {
       "version": "0.39.2",
       "dev": true,
@@ -31884,6 +32688,17 @@
         "eslint-visitor-keys": "^3.4.3"
       }
     },
+    "@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
     "@ungap/structured-clone": {
       "version": "1.3.0",
       "dev": true
@@ -33444,6 +34259,15 @@
       "dev": true,
       "optional": true
     },
+    "bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "requires": {
+        "run-applescript": "^7.0.0"
+      }
+    },
     "byline": {
       "version": "5.0.0",
       "dev": true
@@ -34042,6 +34866,22 @@
     },
     "deepmerge": {
       "version": "4.3.1",
+      "dev": true
+    },
+    "default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "requires": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      }
+    },
+    "default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true
     },
     "defaults": {
@@ -35787,6 +36627,23 @@
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
       "integrity": "sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==",
       "dev": true
+    },
+    "is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^3.0.0"
+      },
+      "dependencies": {
+        "is-docker": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+          "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+          "dev": true
+        }
+      }
     },
     "is-interactive": {
       "version": "1.0.0",
@@ -40970,6 +41827,12 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true
     },
+    "run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -42368,6 +43231,26 @@
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "requires": {}
+    },
+    "wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^3.1.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+          "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+          "dev": true,
+          "requires": {
+            "is-inside-container": "^1.0.0"
+          }
+        }
+      }
     },
     "xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,11 @@
     "unleash-proxy-client": "^3.6.0"
   },
   "devDependencies": {
+    "@azure/app-configuration-provider": "^2.5.1",
+    "@azure/identity": "^4.13.1",
     "@bufbuild/buf": "^1.34.0",
     "@edge-runtime/jest-environment": "^4.0.0",
+    "@microsoft/feature-management": "^2.3.1",
     "@nx/devkit": "22.7.1",
     "@nx/eslint": "22.7.1",
     "@nx/eslint-plugin": "22.7.1",
@@ -96,6 +99,7 @@
     "jest": "30.0.5",
     "jest-cucumber": "^4.4.0",
     "jest-environment-jsdom": "30.0.5",
+    "jest-environment-node": "^30.0.2",
     "jest-fetch-mock": "^3.0.3",
     "jest-util": "30.0.5",
     "jest-websocket-mock": "^2.4.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -185,6 +185,13 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default"
+    },
+    "libs/providers/azure-app-configuration": {
+      "release-type": "node",
+      "prerelease": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default"
     }
   },
   "changelog-sections": [

--- a/tools/workspace-plugin/src/generators/open-feature/index.ts
+++ b/tools/workspace-plugin/src/generators/open-feature/index.ts
@@ -66,8 +66,8 @@ export default async function (tree: Tree, schema: SchemaOptions) {
   updateProject(tree, projectRoot, name);
   updateTsConfig(tree, projectRoot);
   updateEslintrc(tree, projectRoot);
-  updateJestConfig(tree, projectRoot);
-  updateProjectJson(tree, projectRoot);
+  const jestConfigFileName = updateJestConfig(tree, projectRoot);
+  updateProjectJson(tree, projectRoot, jestConfigFileName);
   updatePackage(tree, projectRoot, schema);
   updateReleasePleaseConfig(tree, projectRoot);
   updateReleasePleaseManifest(tree, projectRoot);
@@ -208,8 +208,17 @@ function updateEslintrc(tree: Tree, projectRoot: string) {
   });
 }
 
-function updateJestConfig(tree: Tree, projectRoot: string) {
-  const configPath = joinPathFragments(projectRoot, 'jest.config.ts');
+function updateJestConfig(tree: Tree, projectRoot: string): string {
+  // Nx + Jest 30 generates jest.config.cts (CommonJS TS); older setups use jest.config.ts
+  const jestConfigFileName = ['jest.config.cts', 'jest.config.ts'].find((fileName) =>
+    tree.exists(joinPathFragments(projectRoot, fileName)),
+  );
+
+  if (!jestConfigFileName) {
+    throw new Error(`Could not find a jest config in ${projectRoot}`);
+  }
+
+  const configPath = joinPathFragments(projectRoot, jestConfigFileName);
 
   // Update jest.preset.js path
   let contents = tree.read(configPath)!.toString();
@@ -220,12 +229,14 @@ function updateJestConfig(tree: Tree, projectRoot: string) {
   contents = tree.read(configPath)!.toString();
   const replaceCoveragePath = contents.replace('../coverage/providers', `../../../coverage/${projectRoot}`);
   tree.write(configPath, replaceCoveragePath);
+
+  return jestConfigFileName;
 }
 
-function updateProjectJson(tree: Tree, projectRoot: string) {
-  // Update jest.config.ts location
+function updateProjectJson(tree: Tree, projectRoot: string, jestConfigFileName: string) {
+  // Update jest config location
   updateJson(tree, joinPathFragments(projectRoot, 'project.json'), (json) => {
-    json.targets.test.options.jestConfig = '{projectRoot}/jest.config.ts';
+    json.targets.test.options.jestConfig = `{projectRoot}/${jestConfigFileName}`;
     return json;
   });
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -41,7 +41,8 @@
       "@openfeature/ofrep-core": ["libs/shared/ofrep-core/src/index.ts"],
       "@openfeature/ofrep-provider": ["libs/providers/ofrep/src/index.ts"],
       "@openfeature/ofrep-web-provider": ["libs/providers/ofrep-web/src/index.ts"],
-      "@openfeature/unleash-web-provider": ["libs/providers/unleash-web/src/index.ts"]
+      "@openfeature/unleash-web-provider": ["libs/providers/unleash-web/src/index.ts"],
+      "@openfeature/azure-app-configuration-provider": ["libs/providers/azure-app-configuration/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary

- Add a new `@openfeature/azure-app-configuration-provider` server-side provider that resolves feature flags from Azure App Configuration using `@azure/app-configuration-provider` and `@microsoft/feature-management`. Supports connection string and Entra ID credential auth, configurable selectors and refresh polling, boolean flag evaluation (with targeting/filters), and variant-based string/number/object resolution.
- Fix boolean flag resolution to return the caller's default value with reason `DEFAULT` when a flag is not found, instead of delegating to `FeatureManager.isEnabled` (which could return `false` regardless of the default).
- Fix the OpenFeature workspace generator to detect `jest.config.cts` vs `jest.config.ts` (Nx + Jest 30), preventing a crash when scaffolding new providers/hooks.

## Test plan

- [x] Run `nx test azure-app-configuration` — all unit tests pass
- [x] Run `nx package azure-app-configuration` — library builds successfully
- [x] Verify boolean evaluation returns the default value when a flag key does not exist in Azure App Configuration
- [x] Verify boolean evaluation honors targeting filters (targeting key, groups) for existing flags
- [x] Verify variant resolution (`getStringValue`, `getNumberValue`, `getObjectValue`) returns variant configuration and raises `TypeMismatchError` on type mismatch
- [x] Verify `ConfigurationChanged` events are emitted when refresh detects flag changes (`enableRefresh: true`)
- [x] Smoke-test provider initialization with both connection string and `endpoint` + `DefaultAzureCredential`
