### PR TITLE
fix(ofrep-core): encode flagKey in the evaluate request path

### DIFF
--- a/libs/shared/ofrep-core/src/lib/api/ofrep-api.spec.ts
+++ b/libs/shared/ofrep-core/src/lib/api/ofrep-api.spec.ts
@@ -175,6 +175,25 @@ describe('OFREPApi', () => {
         expect(result.httpStatus).toEqual(200);
       });
 
+      it('encode the flagKey in the evaluate path so reserved characters do not alter the URL', async () => {
+        const capturedUrls: string[] = [];
+        const mockFetch = jest.fn(async (input: RequestInfo | URL) => {
+          capturedUrls.push((input as Request).url);
+          return new Response(
+            JSON.stringify({ key: 'flag/with/slash', value: true, reason: 'STATIC', variant: 'on' }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          );
+        }) as unknown as FetchAPI;
+        const localApi = new OFREPApi({ baseUrl: 'https://localhost:8080' }, mockFetch);
+
+        await localApi.postEvaluateFlag('flag/with/slash').catch(() => undefined);
+
+        expect(capturedUrls[0]).toBe('https://localhost:8080/ofrep/v1/evaluate/flags/flag%2Fwith%2Fslash');
+      });
+
       it('send evaluation context in request body', async () => {
         const result = await api.postEvaluateFlag('context-in-metadata', {
           context: {

--- a/libs/shared/ofrep-core/src/lib/api/ofrep-api.ts
+++ b/libs/shared/ofrep-core/src/lib/api/ofrep-api.ts
@@ -150,7 +150,7 @@ export class OFREPApi {
     flagKey: string,
     evaluationRequest?: EvaluationRequest,
   ): Promise<OFREPApiEvaluationResult> {
-    let url = `${this.baseOptions.baseUrl}/ofrep/v1/evaluate/flags/${flagKey}`;
+    let url = `${this.baseOptions.baseUrl}/ofrep/v1/evaluate/flags/${encodeURIComponent(flagKey)}`;
     if (this.baseOptions.query) {
       url = url + `?${this.baseOptions.query.toString()}`;
     }


### PR DESCRIPTION
## Bug

`OFREPApi.postEvaluateFlag(flagKey)` puts the raw `flagKey` into the request path. A key containing `/` (or other reserved characters like `?`, `#`, spaces) produces a malformed URL or adds extra path segments, changing which endpoint is hit. Issue #1324 flags this as a correctness and security concern.

## Root cause

```ts
let url = `${this.baseOptions.baseUrl}/ofrep/v1/evaluate/flags/${flagKey}`;
```

The `flagKey` is interpolated into the path without encoding. The bulk endpoint (`postBulkEvaluateFlags`) does not carry the key in the path, so this is the only affected site.

## Solution

Encode the segment:

```ts
`.../evaluate/flags/${encodeURIComponent(flagKey)}`
```

Fixes #1324

## Testing

Added a unit test to `ofrep-api.spec.ts` using the suite's existing `jest.fn` fetch mock to capture the outgoing `Request.url`, asserting `postEvaluateFlag('flag/with/slash')` encodes to `.../flags/flag%2Fwith%2Fslash`. Fails before the change (raw slashes), passes after. Full `ofrep-core` suite: 45/45; lint clean.
