### PR TITLE
fix(flagsmith-client)!: return FLAG_NOT_FOUND for missing flags

### DIFF
--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
@@ -301,6 +301,16 @@ describe('FlagsmithProvider', () => {
       expect(details.reason).toEqual('ERROR');
       expect(details.errorCode).toEqual('FLAG_NOT_FOUND');
     });
+    it.each(['constructor', '__proto__', 'hasOwnProperty'])(
+      'should return FLAG_NOT_FOUND for missing flags named after prototype members (%s)',
+      async (flagKey) => {
+        await OpenFeature.setProviderAndWait(provider);
+        const details = client.getStringDetails(flagKey, 'fallback');
+        expect(details.value).toEqual('fallback');
+        expect(details.reason).toEqual('ERROR');
+        expect(details.errorCode).toEqual('FLAG_NOT_FOUND');
+      },
+    );
     it('should not return FLAG_NOT_FOUND for existing flags with differently-cased keys', async () => {
       await OpenFeature.setProviderAndWait(provider);
       const details = client.getStringDetails(exampleStringFlagName.toUpperCase().replace(/_/g, ' '), '');

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.spec.ts
@@ -287,11 +287,25 @@ describe('FlagsmithProvider', () => {
       expect(details.value).toEqual(0);
       expect(details.reason).toEqual('ERROR');
     });
-    it('should use defaults for flags that do not exist', async () => {
+    it('should return FLAG_NOT_FOUND with defaults for flags that do not exist', async () => {
       await OpenFeature.setProviderAndWait(provider);
       const details = client.getNumberDetails('dont exist', 0);
       expect(details.value).toEqual(0);
-      expect(details.reason).toEqual('DEFAULT');
+      expect(details.reason).toEqual('ERROR');
+      expect(details.errorCode).toEqual('FLAG_NOT_FOUND');
+    });
+    it('should return FLAG_NOT_FOUND for boolean flags that do not exist', async () => {
+      await OpenFeature.setProviderAndWait(provider);
+      const details = client.getBooleanDetails('dont exist', true);
+      expect(details.value).toEqual(true);
+      expect(details.reason).toEqual('ERROR');
+      expect(details.errorCode).toEqual('FLAG_NOT_FOUND');
+    });
+    it('should not return FLAG_NOT_FOUND for existing flags with differently-cased keys', async () => {
+      await OpenFeature.setProviderAndWait(provider);
+      const details = client.getStringDetails(exampleStringFlagName.toUpperCase().replace(/_/g, ' '), '');
+      expect(details.value).toEqual('Hello World');
+      expect(details.errorCode).toBeUndefined();
     });
   });
   describe('events', () => {

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
@@ -8,7 +8,7 @@ import type {
   ResolutionDetails,
   ResolutionReason,
 } from '@openfeature/web-sdk';
-import { OpenFeatureEventEmitter, ProviderEvents, TypeMismatchError } from '@openfeature/web-sdk';
+import { FlagNotFoundError, OpenFeatureEventEmitter, ProviderEvents, TypeMismatchError } from '@openfeature/web-sdk';
 import { createFlagsmithInstance } from 'flagsmith';
 import type { ClientEvaluationContext, IFlagsmith, IInitConfig, IState, ITraits } from 'flagsmith/types';
 import type { FlagType } from './type-factory';
@@ -158,6 +158,13 @@ export class FlagsmithClientProvider implements Provider {
    * @private
    */
   private evaluate<T extends FlagValue>(flagKey: string, type: FlagType, defaultValue: T) {
+    // The Flagsmith SDK normalizes flag names before lookup; mirror it for the existence check
+    const normalizedKey = flagKey.toLowerCase().replace(/ /g, '_');
+    const flags = this._client.getState()?.flags;
+    if (!flags || !(normalizedKey in flags)) {
+      throw new FlagNotFoundError(`flag key ${flagKey} was not found`);
+    }
+
     const value = typeFactory(
       type === 'boolean' ? this._client.hasFeature(flagKey) : this._client.getValue(flagKey),
       type,

--- a/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
+++ b/libs/providers/flagsmith-client/src/lib/flagsmith-client-provider.ts
@@ -161,7 +161,7 @@ export class FlagsmithClientProvider implements Provider {
     // The Flagsmith SDK normalizes flag names before lookup; mirror it for the existence check
     const normalizedKey = flagKey.toLowerCase().replace(/ /g, '_');
     const flags = this._client.getState()?.flags;
-    if (!flags || !(normalizedKey in flags)) {
+    if (!flags || !Object.prototype.hasOwnProperty.call(flags, normalizedKey)) {
       throw new FlagNotFoundError(`flag key ${flagKey} was not found`);
     }
 


### PR DESCRIPTION
Evaluating a flag that does not exist in Flagsmith resolves with the default value and reason `DEFAULT` (or `STATIC` for booleans), making missing flags fail silently.

 This PR changes `evaluate()` to check Flagsmith client state for the flag (using the SDK's key normalization) and throws `FlagNotFoundError` so the SDK produces an `ERROR` resolution with errorCode `FLAG_NOT_FOUND`.

Not sure if this should be a breaking change, it does align closer with the spec, but it'll break consumers that rely on no errors raised when flags don't exist

fixes #1581 

