### PR TITLE
feat: Allow overriding SSE message parsing for compat.

### DIFF
--- a/libs/providers/ofrep-web/src/index.ts
+++ b/libs/providers/ofrep-web/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/ofrep-web-provider';
 export type { OFREPWebProviderOptions } from './lib/model/ofrep-web-provider-options';
-export type { SseRefetchMetadata } from './lib/sse-manager';
+export type { SseRefetchMetadata, SseEventParser } from './lib/sse-manager';
+export { defaultSseEventParser } from './lib/sse-manager';

--- a/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
+++ b/libs/providers/ofrep-web/src/lib/model/ofrep-web-provider-options.ts
@@ -1,4 +1,5 @@
 import type { OFREPProviderBaseOptions } from '@openfeature/ofrep-core';
+import type { SseEventParser } from '../sse-manager';
 
 export type CacheMode = 'local-cache-first' | 'network-first' | 'disabled';
 
@@ -30,6 +31,15 @@ export type OFREPWebProviderOptions = OFREPProviderBaseOptions & {
    * If neither is set, defaults to 120 seconds.
    */
   inactivityDelaySec?: number;
+
+  /**
+   * Overrides how the raw SSE event payload is parsed into the OFREP-spec
+   * `EventStreamMessage` the provider acts on. Use this to support non-JSON
+   * wire formats or custom deserialization.
+   *
+   * Default: JSON-parses string payloads, otherwise passes the data through as-is.
+   */
+  sseEventParser?: SseEventParser;
 
   /**
    * Controls the background change-detection strategy per ADR-0008.

--- a/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
+++ b/libs/providers/ofrep-web/src/lib/ofrep-web-provider.ts
@@ -492,6 +492,9 @@ export class OFREPWebProvider implements Provider {
           this._options.inactivityDelaySec,
           this._logger,
           this._options.baseUrl,
+          // Leave EventSource implementation as the default; only tests inject a mock
+          undefined,
+          this._options.sseEventParser,
         );
       }
       this._sseManager.connect(result.eventStreams);

--- a/libs/providers/ofrep-web/src/lib/sse-manager.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/sse-manager.spec.ts
@@ -293,29 +293,51 @@ describe('SseManager', () => {
   });
 
   describe('custom SSE event parser', () => {
-    it('should use the provided parser to deserialize a custom (non-default) wire format', () => {
-      // An Ably-style envelope that wraps the OFREP payload under `data`, which
-      // the default JSON parser would not understand.
-      const customParser: SseEventParser = jest.fn((event: MessageEvent) => {
-        const envelope = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
-        return envelope.data;
-      });
+    // An Ably-style envelope that wraps the OFREP payload under `data`, which the
+    // default JSON parser would not understand. Handles both the already-deserialized
+    // object form and the raw-string form an EventSource might deliver.
+    const wrappedEnvelopeParser: SseEventParser = (event: MessageEvent) => {
+      const envelope = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      return envelope.data;
+    };
 
+    it('should use the provided parser to deserialize a custom object payload', () => {
+      const customParser = jest.fn(wrappedEnvelopeParser);
       const manager = makeMgr(callbacks, undefined, undefined, customParser);
       manager.connect([sseStream('https://sse.example.com/stream')]);
 
+      // EventSource delivered an already-deserialized object.
       MockEventSource.instances[0].simulateRawMessage({
-        data: { type: 'refetchEvaluation', etag: '"wrapped"', lastModified: 1771622898 },
+        data: { type: 'refetchEvaluation', etag: '"wrapped-object"', lastModified: 1771622898 },
       });
 
       jest.advanceTimersByTime(50); // debounce
 
       expect(customParser).toHaveBeenCalledTimes(1);
+      expect(typeof customParser.mock.calls[0][0].data).toBe('object');
       expect(onRefetchMock).toHaveBeenCalledTimes(1);
       expect(onRefetchMock).toHaveBeenCalledWith({
-        flagConfigEtag: '"wrapped"',
+        flagConfigEtag: '"wrapped-object"',
         flagConfigLastModified: 1771622898,
       });
+    });
+
+    it('should use the provided parser to deserialize a custom string payload', () => {
+      const customParser = jest.fn(wrappedEnvelopeParser);
+      const manager = makeMgr(callbacks, undefined, undefined, customParser);
+      manager.connect([sseStream('https://sse.example.com/stream')]);
+
+      // EventSource delivered the same envelope as a raw JSON string.
+      MockEventSource.instances[0].simulateRawMessage(
+        JSON.stringify({ data: { type: 'refetchEvaluation', etag: '"wrapped-string"' } }),
+      );
+
+      jest.advanceTimersByTime(50); // debounce
+
+      expect(customParser).toHaveBeenCalledTimes(1);
+      expect(typeof customParser.mock.calls[0][0].data).toBe('string');
+      expect(onRefetchMock).toHaveBeenCalledTimes(1);
+      expect(onRefetchMock).toHaveBeenCalledWith({ flagConfigEtag: '"wrapped-string"' });
     });
 
     it('should parse a non-JSON payload the default parser could not handle', () => {

--- a/libs/providers/ofrep-web/src/lib/sse-manager.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/sse-manager.spec.ts
@@ -1,4 +1,4 @@
-import { SseManager, DEFAULT_GRACE_PERIOD_SEC } from './sse-manager';
+import { SseManager, DEFAULT_GRACE_PERIOD_SEC, defaultSseEventParser } from './sse-manager';
 import type { SseEventParser, SseManagerCallbacks } from './sse-manager';
 import type { EventStream } from '@openfeature/ofrep-core';
 
@@ -81,6 +81,26 @@ const makeMgr = (callbacks: SseManagerCallbacks, inactivity?: number, baseUrl?: 
     MockEventSource as unknown as typeof EventSource,
     parseEvent,
   );
+
+describe('defaultSseEventParser', () => {
+  it('should JSON-parse a string payload and return the resulting object', () => {
+    const payload = { type: 'refetchEvaluation', etag: '"abc"', lastModified: 1771622898 };
+    const event = new MessageEvent('message', { data: JSON.stringify(payload) });
+
+    const result = defaultSseEventParser(event);
+
+    expect(result).toEqual(payload);
+  });
+
+  it('should pass an already-deserialized object through without modification', () => {
+    const payload = { type: 'refetchEvaluation', etag: '"xyz"' };
+    const event = new MessageEvent('message', { data: payload });
+
+    const result = defaultSseEventParser(event);
+
+    expect(result).toBe(payload);
+  });
+});
 
 describe('SseManager', () => {
   let callbacks: SseManagerCallbacks;
@@ -362,12 +382,26 @@ describe('SseManager', () => {
       const manager = makeMgr(callbacks);
       manager.connect([sseStream('https://sse.example.com/stream')]);
 
-      // Default parser cannot make sense of a wrapped envelope: the outer object
-      // has no `type`, so it is treated as an unknown event and ignored.
+      // simulateRawMessage skips MockEventSource's internal JSON.stringify so the
+      // listener receives a plain string — only defaultSseEventParser's JSON.parse
+      // branch converts it into a structured object, proving it was invoked.
+      MockEventSource.instances[0].simulateRawMessage(
+        JSON.stringify({ type: 'refetchEvaluation', etag: '"default-parser"', lastModified: 1771622898 }),
+      );
+      jest.advanceTimersByTime(50);
+
+      expect(onRefetchMock).toHaveBeenCalledTimes(1);
+      expect(onRefetchMock).toHaveBeenCalledWith({
+        flagConfigEtag: '"default-parser"',
+        flagConfigLastModified: 1771622898,
+      });
+
+      // And it cannot make sense of a wrapped envelope: the outer object has no
+      // `type`, so it is treated as an unknown event and ignored.
+      onRefetchMock.mockClear();
       MockEventSource.instances[0].simulateMessage({
         data: { type: 'refetchEvaluation', etag: '"wrapped"' },
       });
-
       jest.advanceTimersByTime(50);
 
       expect(onRefetchMock).not.toHaveBeenCalled();

--- a/libs/providers/ofrep-web/src/lib/sse-manager.spec.ts
+++ b/libs/providers/ofrep-web/src/lib/sse-manager.spec.ts
@@ -1,5 +1,5 @@
 import { SseManager, DEFAULT_GRACE_PERIOD_SEC } from './sse-manager';
-import type { SseManagerCallbacks } from './sse-manager';
+import type { SseEventParser, SseManagerCallbacks } from './sse-manager';
 import type { EventStream } from '@openfeature/ofrep-core';
 
 // Advance past the grace period to ensure the timer would have fired if not cancelled
@@ -41,6 +41,15 @@ class MockEventSource {
     }
   }
 
+  // Dispatch a raw payload without JSON.stringify — used to exercise custom
+  // wire formats that a custom parser is responsible for deserializing.
+  simulateRawMessage(data: unknown): void {
+    const event = new MessageEvent('message', { data });
+    for (const listener of this.listeners['message'] ?? []) {
+      listener(event);
+    }
+  }
+
   simulateError(fatal = false): void {
     this.readyState = fatal ? 2 : 0; // CLOSED or CONNECTING
     const event = new Event('error');
@@ -63,8 +72,15 @@ class MockEventSource {
 }
 
 // Factory that injects MockEventSource so tests don't need a globalThis override
-const makeMgr = (callbacks: SseManagerCallbacks, inactivity?: number, baseUrl?: string) =>
-  new SseManager(callbacks, inactivity, undefined, baseUrl, MockEventSource as unknown as typeof EventSource);
+const makeMgr = (callbacks: SseManagerCallbacks, inactivity?: number, baseUrl?: string, parseEvent?: SseEventParser) =>
+  new SseManager(
+    callbacks,
+    inactivity,
+    undefined,
+    baseUrl,
+    MockEventSource as unknown as typeof EventSource,
+    parseEvent,
+  );
 
 describe('SseManager', () => {
   let callbacks: SseManagerCallbacks;
@@ -269,6 +285,66 @@ describe('SseManager', () => {
       for (const listener of listeners) {
         listener(event);
       }
+
+      jest.advanceTimersByTime(50);
+
+      expect(onRefetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('custom SSE event parser', () => {
+    it('should use the provided parser to deserialize a custom (non-default) wire format', () => {
+      // An Ably-style envelope that wraps the OFREP payload under `data`, which
+      // the default JSON parser would not understand.
+      const customParser: SseEventParser = jest.fn((event: MessageEvent) => {
+        const envelope = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+        return envelope.data;
+      });
+
+      const manager = makeMgr(callbacks, undefined, undefined, customParser);
+      manager.connect([sseStream('https://sse.example.com/stream')]);
+
+      MockEventSource.instances[0].simulateRawMessage({
+        data: { type: 'refetchEvaluation', etag: '"wrapped"', lastModified: 1771622898 },
+      });
+
+      jest.advanceTimersByTime(50); // debounce
+
+      expect(customParser).toHaveBeenCalledTimes(1);
+      expect(onRefetchMock).toHaveBeenCalledTimes(1);
+      expect(onRefetchMock).toHaveBeenCalledWith({
+        flagConfigEtag: '"wrapped"',
+        flagConfigLastModified: 1771622898,
+      });
+    });
+
+    it('should parse a non-JSON payload the default parser could not handle', () => {
+      // Colon-delimited text format: `<type>:<etag>`
+      const customParser: SseEventParser = (event: MessageEvent) => {
+        const [type, etag] = String(event.data).split(':');
+        return { type, etag };
+      };
+
+      const manager = makeMgr(callbacks, undefined, undefined, customParser);
+      manager.connect([sseStream('https://sse.example.com/stream')]);
+
+      MockEventSource.instances[0].simulateRawMessage('refetchEvaluation:"text-etag"');
+
+      jest.advanceTimersByTime(50);
+
+      expect(onRefetchMock).toHaveBeenCalledTimes(1);
+      expect(onRefetchMock).toHaveBeenCalledWith({ flagConfigEtag: '"text-etag"' });
+    });
+
+    it('should default to JSON parsing when no custom parser is provided', () => {
+      const manager = makeMgr(callbacks);
+      manager.connect([sseStream('https://sse.example.com/stream')]);
+
+      // Default parser cannot make sense of a wrapped envelope: the outer object
+      // has no `type`, so it is treated as an unknown event and ignored.
+      MockEventSource.instances[0].simulateMessage({
+        data: { type: 'refetchEvaluation', etag: '"wrapped"' },
+      });
 
       jest.advanceTimersByTime(50);
 

--- a/libs/providers/ofrep-web/src/lib/sse-manager.ts
+++ b/libs/providers/ofrep-web/src/lib/sse-manager.ts
@@ -1,4 +1,4 @@
-import type { BulkEvaluationRefetchMetadata, EventStream } from '@openfeature/ofrep-core';
+import type { BulkEvaluationRefetchMetadata, EventStream, EventStreamMessage } from '@openfeature/ofrep-core';
 import type { Logger } from '@openfeature/web-sdk';
 
 const DEFAULT_INACTIVITY_DELAY_SEC = 120;
@@ -21,6 +21,20 @@ export interface SseManagerCallbacks {
   onStale: () => void;
   onError: () => void;
 }
+
+/**
+ * Parses the payload of an incoming SSE {@link MessageEvent} into the object the
+ * SseManager inspects for `type`/`etag`/`lastModified`. Override to support
+ * non-JSON payloads or custom wire formats.
+ */
+export type SseEventParser = (event: MessageEvent) => EventStreamMessage;
+
+/**
+ * Default parser: JSON-parses string payloads, otherwise passes the data through
+ * as-is (e.g. when the EventSource implementation already deserialized it).
+ */
+export const defaultSseEventParser: SseEventParser = (event) =>
+  typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
 
 /**
  * Resolves the connection URL from an EventStream entry.
@@ -63,6 +77,8 @@ export class SseManager {
     private _baseUrl?: string,
     // Allows tests to inject a mock instead of the global EventSource
     private _EventSourceImpl: new (url: string) => EventSource = EventSource,
+    // Overrides how incoming SSE payloads are parsed; defaults to JSON parsing
+    private _parseEvent: SseEventParser = defaultSseEventParser,
   ) {
     this._inactivityDelaySec = _clientInactivityOverride ?? DEFAULT_INACTIVITY_DELAY_SEC;
   }
@@ -219,7 +235,7 @@ export class SseManager {
     }
 
     try {
-      const data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      const data = this._parseEvent(event);
 
       if (data.type !== 'refetchEvaluation') {
         // Ignore unknown event types for forward compatibility

--- a/libs/shared/ofrep-core/src/lib/model/event-stream.ts
+++ b/libs/shared/ofrep-core/src/lib/model/event-stream.ts
@@ -34,3 +34,20 @@ export interface EventStream {
    */
   inactivityDelaySec?: number;
 }
+
+/**
+ * The payload of an SSE event delivered over an {@link EventStream} connection.
+ * Per ADR-0008, a `refetchEvaluation` event signals that the client should
+ * re-fetch the bulk evaluation, optionally carrying cache-validation metadata.
+ */
+export interface EventStreamMessage {
+  /**
+   * The event type. Currently only `"refetchEvaluation"` is defined; clients
+   * must ignore events with unknown `type` values for forward compatibility.
+   */
+  type: string;
+  /** ETag of the flag configuration that triggered the event. */
+  etag?: string;
+  /** Last-modified timestamp of the flag configuration. */
+  lastModified?: string | number;
+}


### PR DESCRIPTION

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Not all SSE vendors (namely ably) support directly deserializing the data object with custom body content, and instead wrap it inside of another layer (data.data in Ably's case).
For compatibility with a lot more providers, non-JSON payloads, etc. this will allow more broad implementation adoption.


### Related Issues

https://github.com/open-feature/protocol/pull/82