### PR TITLE
feat(flagd): Support client-certificate mTLS

### DIFF
--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -34,6 +34,8 @@ Options can be defined in the constructor or as environment variables. Construct
 | tls                   | FLAGD_TLS                      | boolean  | false                                                          |                                              |
 | socketPath            | FLAGD_SOCKET_PATH              | string   | -                                                              |                                              |
 | certPath              | FLAGD_SERVER_CERT_PATH         | string   | -                                                              |                                              |
+| clientCertPath        | FLAGD_CLIENT_CERT_PATH         | string   | -                                                              | mTLS; requires clientKeyPath and tls         |
+| clientKeyPath         | FLAGD_CLIENT_KEY_PATH          | string   | -                                                              | mTLS; requires clientCertPath and tls        |
 | resolverType          | FLAGD_RESOLVER                 | string   | rpc                                                            | rpc, in-process                              |
 | offlineFlagSourcePath | FLAGD_OFFLINE_FLAG_SOURCE_PATH | string   | -                                                              |                                              |
 | selector              | FLAGD_SOURCE_SELECTOR          | string   | -                                                              | rpc & in-process (see [Selector](#selector)) |

--- a/libs/providers/flagd/src/lib/configuration.spec.ts
+++ b/libs/providers/flagd/src/lib/configuration.spec.ts
@@ -40,6 +40,8 @@ describe('Configuration', () => {
     const tls = true;
     const socketPath = '/tmp/flagd.socks';
     const certPath = '/etc/cert/ca.crt';
+    const clientCertPath = '/etc/cert/client.crt';
+    const clientKeyPath = '/etc/cert/client.key';
     const maxCacheSize = 333;
     const cache = 'disabled';
     const resolverType = 'in-process';
@@ -55,6 +57,8 @@ describe('Configuration', () => {
     process.env['FLAGD_TLS'] = `${tls}`;
     process.env['FLAGD_SOCKET_PATH'] = socketPath;
     process.env['FLAGD_SERVER_CERT_PATH'] = certPath;
+    process.env['FLAGD_CLIENT_CERT_PATH'] = clientCertPath;
+    process.env['FLAGD_CLIENT_KEY_PATH'] = clientKeyPath;
     process.env['FLAGD_CACHE'] = cache;
     process.env['FLAGD_MAX_CACHE_SIZE'] = `${maxCacheSize}`;
     process.env['FLAGD_SOURCE_SELECTOR'] = `${selector}`;
@@ -72,6 +76,8 @@ describe('Configuration', () => {
         tls,
         socketPath,
         certPath,
+        clientCertPath,
+        clientKeyPath,
         maxCacheSize,
         cache,
         resolverType,

--- a/libs/providers/flagd/src/lib/configuration.ts
+++ b/libs/providers/flagd/src/lib/configuration.ts
@@ -48,6 +48,20 @@ export interface Config {
   certPath?: string;
 
   /**
+   * Client certificate path for mutual TLS (mTLS). Requires {@link clientKeyPath} and TLS enabled.
+   *
+   * @example "/etc/cert/client.crt"
+   */
+  clientCertPath?: string;
+
+  /**
+   * Client private key path for mutual TLS (mTLS). Requires {@link clientCertPath} and TLS enabled.
+   *
+   * @example "/etc/cert/client.key"
+   */
+  clientKeyPath?: string;
+
+  /**
    * Resolver type to use by the provider.
    *
    * Options include rpc & in-process.
@@ -176,6 +190,8 @@ enum ENV_VAR {
   FLAGD_TLS = 'FLAGD_TLS',
   FLAGD_SOCKET_PATH = 'FLAGD_SOCKET_PATH',
   FLAGD_SERVER_CERT_PATH = 'FLAGD_SERVER_CERT_PATH',
+  FLAGD_CLIENT_CERT_PATH = 'FLAGD_CLIENT_CERT_PATH',
+  FLAGD_CLIENT_KEY_PATH = 'FLAGD_CLIENT_KEY_PATH',
   FLAGD_CACHE = 'FLAGD_CACHE',
   FLAGD_MAX_CACHE_SIZE = 'FLAGD_MAX_CACHE_SIZE',
   FLAGD_SOURCE_SELECTOR = 'FLAGD_SOURCE_SELECTOR',
@@ -231,6 +247,12 @@ function getEnvVarConfig(): Partial<Config & FlagdGrpcConfig> {
     }),
     ...(process.env[ENV_VAR.FLAGD_SERVER_CERT_PATH] && {
       certPath: process.env[ENV_VAR.FLAGD_SERVER_CERT_PATH],
+    }),
+    ...(process.env[ENV_VAR.FLAGD_CLIENT_CERT_PATH] && {
+      clientCertPath: process.env[ENV_VAR.FLAGD_CLIENT_CERT_PATH],
+    }),
+    ...(process.env[ENV_VAR.FLAGD_CLIENT_KEY_PATH] && {
+      clientKeyPath: process.env[ENV_VAR.FLAGD_CLIENT_KEY_PATH],
     }),
     ...((process.env[ENV_VAR.FLAGD_CACHE] === 'lru' || process.env[ENV_VAR.FLAGD_CACHE] === 'disabled') && {
       cache: process.env[ENV_VAR.FLAGD_CACHE],

--- a/libs/providers/flagd/src/lib/service/common/grpc-util.spec.ts
+++ b/libs/providers/flagd/src/lib/service/common/grpc-util.spec.ts
@@ -1,12 +1,16 @@
 import {
   buildClientOptions,
   buildRetryPolicy,
+  createChannelCredentials,
   createFatalStatusCodesSet,
   handleFatalStatusCodeError,
   isFatalStatusCodeError,
 } from './grpc-util';
 import type { ServiceError } from '@grpc/grpc-js';
-import { status } from '@grpc/grpc-js';
+import { credentials, status } from '@grpc/grpc-js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import type { Config } from '../../configuration';
 import type { Logger } from '@openfeature/server-sdk';
@@ -16,6 +20,77 @@ const createMockLogger = (): Logger => ({
   warn: jest.fn(),
   info: jest.fn(),
   debug: jest.fn(),
+});
+
+describe('createChannelCredentials', () => {
+  let dir: string;
+  let caPath: string;
+  let clientCertPath: string;
+  let clientKeyPath: string;
+  let caBuf: Buffer;
+  let certBuf: Buffer;
+  let keyBuf: Buffer;
+
+  let createInsecureSpy: jest.SpyInstance;
+  let createSslSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'flagd-mtls-'));
+    caPath = join(dir, 'ca.crt');
+    clientCertPath = join(dir, 'client.crt');
+    clientKeyPath = join(dir, 'client.key');
+    caBuf = Buffer.from('ca-cert');
+    certBuf = Buffer.from('client-cert');
+    keyBuf = Buffer.from('client-key');
+    writeFileSync(caPath, caBuf);
+    writeFileSync(clientCertPath, certBuf);
+    writeFileSync(clientKeyPath, keyBuf);
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    // Spy on the real credentials factory rather than mocking the module, so @grpc/grpc-js loads.
+    createInsecureSpy = jest.spyOn(credentials, 'createInsecure').mockReturnValue({} as never);
+    createSslSpy = jest.spyOn(credentials, 'createSsl').mockReturnValue({} as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should create insecure credentials when TLS is disabled', () => {
+    createChannelCredentials(false);
+    expect(createInsecureSpy).toHaveBeenCalledTimes(1);
+    expect(createSslSpy).not.toHaveBeenCalled();
+  });
+
+  it('should create SSL credentials with system trust store when no cert paths are set', () => {
+    createChannelCredentials(true);
+    expect(createSslSpy).toHaveBeenCalledWith(null);
+  });
+
+  it('should create SSL credentials with a root cert when certPath is set', () => {
+    createChannelCredentials(true, caPath);
+    expect(createSslSpy).toHaveBeenCalledWith(caBuf);
+  });
+
+  it('should create mTLS credentials when both client cert and key paths are set', () => {
+    createChannelCredentials(true, caPath, clientCertPath, clientKeyPath);
+    expect(createSslSpy).toHaveBeenCalledWith(caBuf, keyBuf, certBuf);
+  });
+
+  it('should create mTLS credentials with null root certs when certPath is omitted', () => {
+    createChannelCredentials(true, undefined, clientCertPath, clientKeyPath);
+    expect(createSslSpy).toHaveBeenCalledWith(null, keyBuf, certBuf);
+  });
+
+  it('should fall back to server-side TLS when only the client cert path is set', () => {
+    createChannelCredentials(true, undefined, clientCertPath);
+    expect(createSslSpy).toHaveBeenCalledWith(null);
+  });
 });
 
 describe('buildClientOptions', () => {

--- a/libs/providers/flagd/src/lib/service/common/grpc-util.ts
+++ b/libs/providers/flagd/src/lib/service/common/grpc-util.ts
@@ -27,17 +27,33 @@ export const closeStreamIfDefined = (stream: ClientReadableStream<unknown> | und
 
 /**
  * Creates gRPC channel credentials based on TLS and certificate path configuration.
+ *
+ * When both `clientCertPath` and `clientKeyPath` are provided, mutual TLS (mTLS) is used: the
+ * client presents its certificate and key for authentication. `certPath` (the CA / root cert) is
+ * optional and independent — when omitted, the system trust store verifies the server.
+ *
  * @returns Channel credentials for gRPC connection
  */
-export const createChannelCredentials = (tls: boolean, certPath?: string): ChannelCredentials => {
+export const createChannelCredentials = (
+  tls: boolean,
+  certPath?: string,
+  clientCertPath?: string,
+  clientKeyPath?: string,
+): ChannelCredentials => {
   if (!tls) {
     return credentials.createInsecure();
   }
-  if (certPath && existsSync(certPath)) {
-    const rootCerts = readFileSync(certPath);
-    return credentials.createSsl(rootCerts);
+
+  const rootCerts = certPath && existsSync(certPath) ? readFileSync(certPath) : null;
+
+  // Mutual TLS: present the client certificate and key. Both paths are required together.
+  if (clientCertPath && existsSync(clientCertPath) && clientKeyPath && existsSync(clientKeyPath)) {
+    const privateKey = readFileSync(clientKeyPath);
+    const certChain = readFileSync(clientCertPath);
+    return credentials.createSsl(rootCerts, privateKey, certChain);
   }
-  return credentials.createSsl();
+
+  return credentials.createSsl(rootCerts);
 };
 
 /**

--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -98,9 +98,9 @@ export class GRPCService implements Service {
     client?: ServiceClient,
     private logger?: Logger,
   ) {
-    const { host, port, tls, socketPath, certPath } = config;
+    const { host, port, tls, socketPath, certPath, clientCertPath, clientKeyPath } = config;
     const clientOptions = buildClientOptions(config);
-    const channelCredentials = createChannelCredentials(tls, certPath);
+    const channelCredentials = createChannelCredentials(tls, certPath, clientCertPath, clientKeyPath);
 
     this._maxBackoffMs = config.retryBackoffMaxMs || DEFAULT_MAX_BACKOFF_MS;
     this._client = client

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
@@ -50,9 +50,9 @@ export class GrpcFetch implements DataFetch {
     syncServiceClient?: FlagSyncServiceClient,
     logger?: Logger,
   ) {
-    const { host, port, tls, socketPath, certPath, selector } = config;
+    const { host, port, tls, socketPath, certPath, clientCertPath, clientKeyPath, selector } = config;
     const clientOptions = buildClientOptions(config);
-    const channelCredentials = createChannelCredentials(tls, certPath);
+    const channelCredentials = createChannelCredentials(tls, certPath, clientCertPath, clientKeyPath);
 
     this._syncClient = syncServiceClient
       ? syncServiceClient


### PR DESCRIPTION
## This PR

Closes #1587

Adds client-certificate mutual TLS (mTLS) support to the flagd provider gRPC channel.

## Problem

The provider builds the gRPC channel with `credentials.createSsl()` and calls it with no arguments, so it cannot present a client certificate. The `Config` interface has a server-certificate field (`certPath`) but no field for a client certificate or client key. The `@grpc/grpc-js` function `credentials.createSsl(rootCerts, privateKey, certChain)` supports mTLS, but the provider does not use these parameters.

## Change

- Add `clientCertPath` and `clientKeyPath` options to `Config`.
- Add `FLAGD_CLIENT_CERT_PATH` and `FLAGD_CLIENT_KEY_PATH` environment variables.
- Update `createChannelCredentials`: when both client paths are set and both files exist, build credentials with `credentials.createSsl(rootCerts, privateKey, certChain)`.
- Thread the two options through the RPC resolver (`grpc-service.ts`) and the in-process resolver (`grpc-fetch.ts`).
- Document the two options in the README.

## Compatibility

Backward compatible. The mTLS path starts only when both new options are present. The default behavior does not change.

## Tests

New unit tests for `createChannelCredentials` cover insecure, server-side TLS, and mTLS credential construction. They use real temporary cert files and spy on the `@grpc/grpc-js` `credentials` factory to assert the exact arguments.

```
$ npx nx test providers-flagd -- -t "createChannelCredentials"

  createChannelCredentials
    ✓ should create insecure credentials when TLS is disabled
    ✓ should create SSL credentials with system trust store when no cert paths are set
    ✓ should create SSL credentials with a root cert when certPath is set
    ✓ should create mTLS credentials when both client cert and key paths are set
    ✓ should create mTLS credentials with null root certs when certPath is omitted
    ✓ should fall back to server-side TLS when only the client cert path is set

Tests: 6 passed, 6 total
```

Full provider suite is green with the change:

```
$ npx nx test providers-flagd

Test Suites: 6 passed, 6 total
Tests:       165 passed, 165 total
```
