### PR TITLE
chore(ofrep-web): require @openfeature/ofrep-core ^2.3.0

### DIFF
--- a/libs/providers/ofrep-web/package.json
+++ b/libs/providers/ofrep-web/package.json
@@ -17,6 +17,6 @@
     "@openfeature/web-sdk": "^1.4.0"
   },
   "dependencies": {
-    "@openfeature/ofrep-core": "^2.2.0"
+    "@openfeature/ofrep-core": "^2.3.0"
   }
 }


### PR DESCRIPTION
ofrep-web now imports `EventStreamMessage` from `@openfeature/ofrep-core` (added in #1583), which is only available from ofrep-core 2.3.0. Bump the minimum from `^2.2.0` to `^2.3.0`.

Note: CI will fail until ofrep-core 2.3.0 is published to npm; that's expected. Merge once the core release lands.