### PR TITLE
fix(flagd): handle graceful stream end in RPC and in-process resolvers

### DIFF
--- a/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
+++ b/libs/providers/flagd/src/lib/service/grpc/grpc-service.ts
@@ -203,7 +203,11 @@ export class GRPCService implements Service {
       } else {
         const streamDeadline = this._streamDeadline != 0 ? Date.now() + this._streamDeadline : undefined;
         const stream = this._client.eventStream({}, { deadline: streamDeadline });
+        // Guard prevents double-reconnect when grpc-js emits 'end' then 'error' on a non-OK close.
+        let streamTerminated = false;
         stream.on('error', (err: Error) => {
+          if (streamTerminated) return;
+          streamTerminated = true;
           // In cases where we get an explicit error status, we add a delay.
           // This prevents tight loops when errors are returned immediately, typically by intervening proxies like Envoy.
           this._errorThrottled = true;
@@ -213,6 +217,12 @@ export class GRPCService implements Service {
             return;
           }
           rejectConnect?.(err);
+          this.handleError(reconnectCallback, changedCallback, disconnectCallback);
+        });
+        stream.on('end', () => {
+          if (streamTerminated) return;
+          streamTerminated = true;
+          rejectConnect?.(new Error('streaming connection closed by server before ready'));
           this.handleError(reconnectCallback, changedCallback, disconnectCallback);
         });
         stream.on('data', (message) => {

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.spec.ts
@@ -24,6 +24,7 @@ const setSyncContext = jest.fn();
 
 let onDataCallback: (data: SyncFlagsResponse) => void = () => ({});
 let onErrorCallback: (err: Error) => void = () => ({});
+let onEndCallback: () => void = () => ({});
 
 const serviceMock: FlagSyncServiceClient = {
   getChannel: jest.fn(() => {
@@ -34,11 +35,13 @@ const serviceMock: FlagSyncServiceClient = {
   }),
   syncFlags: jest.fn(() => {
     return {
-      on: jest.fn((event: 'data' | 'error', callback: (data: SyncFlagsResponse | Error) => void) => {
+      on: jest.fn((event: 'data' | 'error' | 'end', callback: (data: SyncFlagsResponse | Error) => void) => {
         if (event === 'data') {
           onDataCallback = callback;
         } else if (event === 'error') {
           onErrorCallback = callback;
+        } else if (event === 'end') {
+          onEndCallback = callback as () => void;
         }
         return {};
       }),
@@ -163,6 +166,71 @@ describe('grpc fetch', () => {
     dataCallback.mockReturnValue(['test']);
 
     // First connection
+    onDataCallback({ flagConfiguration: initFlagConfig });
+  });
+
+  it('should reconnect when stream ends gracefully (server-side OK close)', (done) => {
+    const initFlagConfig = '{"flags":{}}';
+    const reconnectFlagConfig =
+      '{"flags":{"test":{"state":"ENABLED","variants":{"on":true,"off":false},"defaultVariant":"on"}}}';
+
+    const fetch = new GrpcFetch(cfg, jest.fn(), serviceMock);
+    fetch
+      .connect(dataCallback, reconnectCallback, changedCallback, disconnectCallback)
+      .then(() => {
+        try {
+          // Server closes the stream gracefully (HTTP/2 END_STREAM with OK status)
+          onEndCallback();
+          // No throttle on graceful close — setTimeout delay is 0
+          jest.runAllTimers();
+          // Reconnect fires a new syncFlags call; simulate the first data on the new stream
+          onDataCallback({ flagConfiguration: reconnectFlagConfig });
+
+          expect(disconnectCallback).toHaveBeenCalledTimes(1);
+          expect(reconnectCallback).toHaveBeenCalledTimes(1);
+          // Old stream must be cleaned up before the new one is opened
+          expect(removeAllListeners).toHaveBeenCalledTimes(1);
+          expect(cancel).toHaveBeenCalledTimes(1);
+          expect(destroy).toHaveBeenCalledTimes(1);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      })
+      .catch((err) => done(err));
+
+    dataCallback.mockReturnValue([]);
+    onDataCallback({ flagConfiguration: initFlagConfig });
+  });
+
+  it('should not double-reconnect on non-OK stream close (end then error)', (done) => {
+    const initFlagConfig = '{"flags":{}}';
+    const reconnectFlagConfig =
+      '{"flags":{"test":{"state":"ENABLED","variants":{"on":true,"off":false},"defaultVariant":"on"}}}';
+
+    const fetch = new GrpcFetch(cfg, jest.fn(), serviceMock);
+    fetch
+      .connect(dataCallback, reconnectCallback, changedCallback, disconnectCallback)
+      .then(() => {
+        try {
+          // grpc-js emits 'end' then 'error' when the server closes with a non-OK status
+          onEndCallback();
+          onErrorCallback(new Error('non-OK status'));
+
+          jest.runAllTimers();
+          onDataCallback({ flagConfiguration: reconnectFlagConfig });
+
+          // Only one reconnect cycle despite both handlers firing
+          expect(disconnectCallback).toHaveBeenCalledTimes(1);
+          expect(reconnectCallback).toHaveBeenCalledTimes(1);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      })
+      .catch((err) => done(err));
+
+    dataCallback.mockReturnValue([]);
     onDataCallback({ flagConfiguration: initFlagConfig });
   });
 

--- a/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
+++ b/libs/providers/flagd/src/lib/service/in-process/grpc/grpc-fetch.ts
@@ -147,7 +147,11 @@ export class GrpcFetch implements DataFetch {
             }
             this._isConnected = true;
           });
+          // Guard prevents double-reconnect when grpc-js emits 'end' then 'error' on a non-OK close.
+          let streamTerminated = false;
           stream.on('error', (err: ServiceError | undefined) => {
+            if (streamTerminated) return;
+            streamTerminated = true;
             // In cases where we get an explicit error status, we add a delay.
             // This prevents tight loops when errors are returned immediately, typically by intervening proxies like Envoy.
             this._errorThrottled = true;
@@ -158,6 +162,18 @@ export class GrpcFetch implements DataFetch {
               changedCallback,
               disconnectCallback,
               rejectConnect,
+            );
+          });
+          stream.on('end', () => {
+            if (streamTerminated) return;
+            streamTerminated = true;
+            rejectConnect?.(new Error('syncFlags stream closed by server before ready'));
+            this.handleError(
+              new Error('syncFlags stream closed by server'),
+              dataCallback,
+              reconnectCallback,
+              changedCallback,
+              disconnectCallback,
             );
           });
           this._syncStream = stream;


### PR DESCRIPTION


## This PR
gRPC-js emits 'end' (not 'error') when the server closes a stream gracefully (HTTP/2 END_STREAM with OK status). Without a handler this event is silently dropped, leaving the stream half-open and the provider serving stale flag values indefinitely.

Add a stream.on('end') handler to both the RPC eventStream resolver (grpc-service.ts) and the in-process syncFlags resolver (grpc-fetch.ts) that triggers reconnection via handleError

## Fix
Add \`stream.on('end', ...)\` to both resolvers that calls \`handleError\` to trigger reconnection. 

## Test
Regression test added to \`grpc-fetch.spec.ts\` covering the graceful-close → reconnect path."

